### PR TITLE
Consume extra LF much like BufferedReader does

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -117,6 +117,8 @@ public class ConsoleReader
 
     private URL inputrcUrl;
 
+    private boolean skipLF = false;
+
     public ConsoleReader() throws IOException {
         this(null, new FileInputStream(FileDescriptor.in), System.out, null);
     }
@@ -1774,20 +1776,32 @@ public class ConsoleReader
     private String readLineSimple() throws IOException {
         StringBuilder buff = new StringBuilder();
 
-        while (true) {
-            int i = readCharater();
-
-            if (i == -1) {
-                return null;
-            }
-            if (i == '\n' || i == '\r') {
+        if (skipLF) {
+            skipLF = false;
+            
+            int i = readCharacter();
+            
+            if (i == -1 || i == '\r') {
                 return buff.toString();
+            } else if (i == '\n') {
+                // ignore
+            } else {
+                buff.append((char) i);
             }
+        }        
+        
+        while (true) {
+            int i = readCharacter();
 
-            buff.append((char) i);
+            if (i == -1 || i == '\n') {
+                return buff.toString();
+            } else if (i == '\r') {
+                skipLF = true;
+                return buff.toString();
+            } else {
+                buff.append((char) i);
+            }
         }
-
-        // return new BufferedReader (new InputStreamReader (in)).readLine ();
     }
 
     //


### PR DESCRIPTION
After entering some text and pressing enter ConsoleReader.readLine() immediately returns an empty string on the second call. That's because on Windows the EOL marker is CRLF but ConsoleReader.readLineSimple() only consumes the CR. 
My changes to the ConsoleReader.java ensure that the extra LF character is consumed. This works pretty much the same as BufferedReader does.
