### PR TITLE
Clear input buffer when using custom callbacks

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -1211,6 +1211,7 @@ public class ConsoleReader
                 // Handle custom callbacks
                 if (o instanceof ActionListener) {
                     ((ActionListener) o).actionPerformed(null);
+                    sb.setLength( 0 );
                     continue;
                 }
 


### PR DESCRIPTION
Currently using custom callbacks is broken because sb is never cleared after processing the ActionListener.
