### PR TITLE
Implement delete next word (M-d)

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -826,6 +826,18 @@ public class ConsoleReader
         return true;
     }
 
+    private boolean deleteNextWord() throws IOException {
+        while (isDelimiter(buf.nextChar()) && delete()) {
+
+        }
+
+        while (!isDelimiter(buf.nextChar()) && delete()) {
+            // nothing
+        }
+
+        return true;
+    }
+
     private boolean capitalizeWord() throws IOException {
         boolean first = true;
         int i = 1;
@@ -1364,7 +1376,9 @@ public class ConsoleReader
                                 // in theory, those are slightly different
                                 success = deletePreviousWord();
                                 break;
-
+                            case KILL_WORD:
+                                success = deleteNextWord();
+                                break;
                             case BEGINNING_OF_HISTORY:
                                 success = history.moveToFirst();
                                 if (success) {

--- a/src/main/java/jline/console/CursorBuffer.java
+++ b/src/main/java/jline/console/CursorBuffer.java
@@ -34,6 +34,14 @@ public class CursorBuffer
         return buffer.length();
     }
 
+    public char nextChar() {
+        if (cursor == buffer.length()) {
+            return 0;
+        } else {
+            return buffer.charAt(cursor);
+        }
+    }
+
     public char current() {
         if (cursor <= 0) {
             return 0;


### PR DESCRIPTION
While M-d is currently mapped to KILL_WORD, that operation is not actually implemented. This fixes that by implementing a deleteNextWord() to complement deletePreviousWord() and mapping it to Operation.KILL_WORD

This should address part of the problem with issue #12
