### PR TITLE
Fixed FORWARD_WORD to actually match readline behavior

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -803,11 +803,11 @@ public class ConsoleReader
     }
 
     private boolean nextWord() throws IOException {
-        while (isDelimiter(buf.current()) && (moveCursor(1) != 0)) {
+        while (isDelimiter(buf.nextChar()) && (moveCursor(1) != 0)) {
             // nothing
         }
 
-        while (!isDelimiter(buf.current()) && (moveCursor(1) != 0)) {
+        while (!isDelimiter(buf.nextChar()) && (moveCursor(1) != 0)) {
             // nothing
         }
 


### PR DESCRIPTION
The current implementation of FORWARD_WORD does not actually match readline behavior. It incorrectly moves one separator past the end of the word. To illustrate (using | to show the cursor):

Current behavior:

```
|one two
one |two
```

Readline behavior:

```
|one two
one| two
```

The current problem is because the logic in nextWord() is implementing by looking at the character before the cursor instead of the character after cursor. This pull request fixes this problem and results in matching the behavior of readline.
