### PR TITLE
Prevent unnecessary empty lines in completion list

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -1989,6 +1989,7 @@ public class ConsoleReader
         for (CharSequence item : items) {
             maxWidth = Math.max(maxWidth, item.length());
         }
+        maxWidth = maxWidth + 3;
         Log.debug("Max width: ", maxWidth);
 
         int showLines;
@@ -2029,7 +2030,7 @@ public class ConsoleReader
 
             // NOTE: toString() is important here due to AnsiString being retarded
             buff.append(item.toString());
-            for (int i = 0; i < (maxWidth + 3 - item.length()); i++) {
+            for (int i = 0; i < (maxWidth - item.length()); i++) {
                 buff.append(' ');
             }
         }


### PR DESCRIPTION
The 3-space pad between columns should be taken into account for the calculation of how many columns to use, not just when adding padding.

Currently, if the terminal window is sized just right (modulo 3 of exact multiples of the max width), I get blank lines in the list of possible completions. This patch prevents that.
