### PR TITLE
Escape history entries only from the reader

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -372,9 +372,11 @@ public class ConsoleReader
      */
     final String finishBuffer() throws IOException { // FIXME: Package protected because used by tests
         String str = buf.buffer.toString();
+        String historyLine = str;
 
         if (expandEvents) {
             str = expandEvents(str);
+            historyLine = str.replaceAll("\\!", "\\\\!");
         }
 
         // we only add it to the history if the buffer is not empty
@@ -382,7 +384,7 @@ public class ConsoleReader
         // the string was a password. We clear the mask after this call
         if (str.length() > 0) {
             if (mask == null && isHistoryEnabled()) {
-                history.add(str);
+                history.add(historyLine);
             }
             else {
                 mask = null;

--- a/src/main/java/jline/console/history/MemoryHistory.java
+++ b/src/main/java/jline/console/history/MemoryHistory.java
@@ -99,7 +99,6 @@ public class MemoryHistory
         if (isAutoTrim()) {
             item = String.valueOf(item).trim();
         }
-        item = item.toString().replaceAll("\\!", "\\\\!");
 
         if (isIgnoreDuplicates()) {
             if (!items.isEmpty() && item.equals(items.getLast())) {
@@ -139,7 +138,7 @@ public class MemoryHistory
     }
 
     public Iterator<Entry> iterator() {
-        return entries();    
+        return entries();
     }
 
     private static class EntryImpl

--- a/src/test/java/jline/console/ConsoleReaderTest.java
+++ b/src/test/java/jline/console/ConsoleReaderTest.java
@@ -265,6 +265,34 @@ public class ConsoleReaderTest
     }
 
     @Test
+    public void testStoringHistory() throws Exception {
+        ConsoleReader reader = createConsole("foo ! bar\r\n");
+        MemoryHistory history = new MemoryHistory();
+        reader.setHistory(history);
+        reader.setExpandEvents(true);
+
+        String line = reader.readLine();
+        assertEquals("foo ! bar", line);
+
+        history.previous();
+        assertEquals("foo \\! bar", history.current());
+    }
+
+    @Test
+    public void testStoringHistoryWithExpandEventsOff() throws Exception {
+        ConsoleReader reader = createConsole("foo ! bar\r\n");
+        MemoryHistory history = new MemoryHistory();
+        reader.setHistory(history);
+        reader.setExpandEvents(false);
+
+        String line = reader.readLine();
+        assertEquals("foo ! bar", line);
+
+        history.previous();
+        assertEquals("foo ! bar", history.current());
+    }
+
+    @Test
     public void testMacro() throws Exception {
         ConsoleReader consoleReader = createConsole("\u0018(foo\u0018)\u0018e\r\n");
         assertNotNull(consoleReader);

--- a/src/test/java/jline/console/history/MemoryHistoryTest.java
+++ b/src/test/java/jline/console/history/MemoryHistoryTest.java
@@ -51,17 +51,6 @@ public class MemoryHistoryTest
         assertEquals(1, history.index());
     }
 
-    @Test
-    public void testAddWithEscape() {
-        assertEquals(0, history.size());
-
-        history.add("foo!bar");
-
-        assertEquals(1, history.size());
-        assertEquals("foo\\!bar", history.get(0));
-        assertEquals(1, history.index());
-    }
-
     private void assertHistoryContains(final int offset, final String... items) {
         assertEquals(items.length, history.size());
         int i=0;
@@ -74,7 +63,7 @@ public class MemoryHistoryTest
     @Test
     public void testOffset() {
         history.setMaxSize(5);
-        
+
         assertEquals(0, history.size());
         assertEquals(0, history.index());
 


### PR DESCRIPTION
This way we can adhere to the expandEvents configuration.

refs #17
