### PR TITLE
don't print an error when failing to query stty information

### DIFF
--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -85,17 +85,22 @@ public final class TerminalLineSettings
      */
     public int getProperty(String name) {
         checkNotNull(name);
+        long currentTime = System.currentTimeMillis();
         try {
             // tty properties are cached so we don't have to worry too much about getting term widht/height
-            if (config == null || System.currentTimeMillis() - configLastFetched > 1000 ) {
+            if (config == null || currentTime - configLastFetched > 1000) {
                 config = get("-a");
-                configLastFetched = System.currentTimeMillis();
             }
-            return this.getProperty(name, config);
         } catch (Exception e) {
-            Log.warn("Failed to query stty ", name, e);            
-            return -1;
+            Log.debug("Failed to query stty ", name, "\n", e);
         }
+
+        // always update the last fetched time and try to parse the output
+        if (currentTime - configLastFetched > 1000) {
+            configLastFetched = currentTime;
+        }
+
+        return this.getProperty(name, config);
     }
 
     /**
@@ -219,3 +224,4 @@ public final class TerminalLineSettings
         }
     }
 }
+


### PR DESCRIPTION
When trying to execute stty to get terminal properties the code can trigger
an InterruptedException even though we've read all of the output from stty
or at least enough for what we need. Instead of printing a warning and
returning -1 in this case instead try to parse what data we do have and
reset the cache timer.

This fixes https://github.com/jline/jline2/issues/29 which we are getting with CraftBukkit.
