### PR TITLE
use jansi's windows support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,10 +254,6 @@
                                         <exclude>junit/**</exclude>
                                         <exclude>org/junit/**</exclude>
                                         <exclude>org/hamcrest/**</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/Jni*</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/*Flag*</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/T32*</exclude>
-                                        <exclude>org/fusesource/hawtjni/runtime/NativeStats*</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/src/main/java/jline/AnsiWindowsTerminal.java
+++ b/src/main/java/jline/AnsiWindowsTerminal.java
@@ -64,6 +64,8 @@ public class AnsiWindowsTerminal
     }
 
     private static boolean detectAnsiSupport() {
+        AnsiConsole.systemInstall();
+
         OutputStream out = AnsiConsole.wrapOutputStream(new ByteArrayOutputStream());
         try {
             out.close();


### PR DESCRIPTION
Change jansi shading to include JNI package for Windows support and enable
it in AnsiWindowsTerminal so Windows users can have working ansi support
without installing extra programs.
