### PR TITLE
Handle ctrl-arrow-keys under linux

### DIFF
--- a/src/main/java/jline/console/KeyMap.java
+++ b/src/main/java/jline/console/KeyMap.java
@@ -194,6 +194,13 @@ public class KeyMap {
         bind( map, "\0340P", Operation.NEXT_HISTORY );
         bind( map, "\0340M", Operation.FORWARD_CHAR );
         bind( map, "\0340K", Operation.BACKWARD_CHAR );
+
+        // Linux
+        bind( map, "\033[1;5D", Operation.BACKWARD_WORD );
+        bind( map, "\033[1;5C", Operation.FORWARD_WORD );
+        bind( map, "\033[1;5A", null );
+        bind( map, "\033[1;5B", null );
+
     }
 
 //    public boolean isConvertMetaCharsToAscii() {


### PR DESCRIPTION
Currently, the combination ctrl-left-arrow-key prints out "'1;5D". It should be handled as backward-word.
