### PR TITLE
Handle EOF / Ctrl-D on unsupported terminals

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -2831,6 +2831,10 @@ public class ConsoleReader
         while (true) {
             int i = readCharacter();
 
+            if (i == -1 && buff.length() == 0) {
+              return null;
+            }
+
             if (i == -1 || i == '\n') {
                 return buff.toString();
             } else if (i == '\r') {


### PR DESCRIPTION
When we have an UnsupportedTerminal, there's no way to get `null` back from `ConsoleReader.readLine()`, so programs calling it have no way to tell the difference between EOF and a newline.

This patch returns `null` where `readCharacter()` says we have an EOF _and_ the buffer is empty, which matches the `readLine()` [behavior for supported terminals](https://github.com/jline/jline2/blob/cf990015080a1e57a5a5e5f32e110cf0c76576b1/src/main/java/jline/console/ConsoleReader.java#L2473-2475).
