### PR TITLE
Distinguish carriage return from newline

### DIFF
--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -49,7 +49,8 @@ public class UnixTerminal
         setAnsiSupported(true);
 
         // set the console to be character-buffered instead of line-buffered
-        settings.set("-icanon min 1");
+        // also make sure we're distinguishing carriage return from newline
+        settings.set("-icanon min 1 -icrnl -inlcr");
 
         setEchoEnabled(false);
     }


### PR DESCRIPTION
This is for issue #48 - found these when reading the man pages for `stty`, and verified that readline itself is forcing this setting off to accommodate this kind of scenario, in `rltty.c`'s `prepare_terminal_settings` function:

```
/* Make sure we differentiate between CR and NL on input. */
tiop->c_iflag &= ~(ICRNL | INLCR);
```

So I think it makes sense for jline to do the same thing.
