### PR TITLE
Up the version to 2.9 in dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use the following definition to use JLine in your maven project:
     <dependency>
       <groupId>jline</groupId>
       <artifactId>jline</artifactId>
-      <version>2.6</version>
+      <version>2.9</version>
     </dependency>
 
 Building


### PR DESCRIPTION
The readme was still showing the old 2.6 version in the dependency snippet.
This change just updates the version to 2.9.
