### PR TITLE
vi-search fix: CR (instead of NL) completes search

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -1520,7 +1520,8 @@ public class ConsoleReader
                         isAborted = true;
                     }
                     break;
-                case '\012': // Enter
+                case '\012': // NL
+                case '\015': // CR
                     isComplete = true;
                     break;
                 default:

--- a/src/test/java/jline/console/ConsoleReaderTestSupport.java
+++ b/src/test/java/jline/console/ConsoleReaderTestSupport.java
@@ -162,6 +162,10 @@ public abstract class ConsoleReaderTestSupport
         public Buffer enter() {
             return ctrl('J');
         }
+        
+        public Buffer CR() {
+        	return ctrl('M');
+        }
 
         public Buffer ctrlU() {
             return append("\025");

--- a/src/test/java/jline/console/ViMoveModeTest.java
+++ b/src/test/java/jline/console/ViMoveModeTest.java
@@ -697,6 +697,23 @@ public class ViMoveModeTest
                               // use "n" and "N" to move.
             .enter();
         assertLine("Xaaadef", b, false);
+        
+        /*
+         * Test bug fix: use CR to terminate seach instead of newline
+         */
+        console.setKeyMap(KeyMap.VI_INSERT);
+        b = (new Buffer("abc"))
+            .enter()
+            .append("def")
+            .enter()
+            .append("hij")
+            .enter()
+            .escape()
+            .append("/bc")
+            .CR()
+            .append("iX")
+            .enter();
+        assertLine("Xabc", b, false);
     }
     
     @Test


### PR DESCRIPTION
Minor (but annoying) bug fix. In vi mode, you can get stuck while typing in a search because the search code only recognized new-line to finish the search and not CR
