### PR TITLE
Fix to ConsoleReader.expandEvents for numeric expansion

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -654,14 +654,14 @@ public class ConsoleReader
                                     throw new IllegalArgumentException((neg ? "!-" : "!") + str.substring(i1, i) + ": event not found");
                                 }
                                 if (neg) {
-                                    if (idx < history.size()) {
+                                    if (idx > 0 && idx <= history.size()) {
                                         rep = (history.get(history.index() - idx)).toString();
                                     } else {
                                         throw new IllegalArgumentException((neg ? "!-" : "!") + str.substring(i1, i) + ": event not found");
                                     }
                                 } else {
-                                    if (idx >= history.index() - history.size() && idx < history.index()) {
-                                        rep = (history.get(idx)).toString();
+                                    if (idx > history.index() - history.size() && idx <= history.index()) {
+                                        rep = (history.get(idx - 1)).toString();
                                     } else {
                                         throw new IllegalArgumentException((neg ? "!-" : "!") + str.substring(i1, i) + ": event not found");
                                     }


### PR DESCRIPTION
Fixes #65. I also adding a ConsolerReaderTest.testNumericExpansions test method that validates the edge cases missed in the current implementation. Because you will only see the first failure, I'm showing that method below and commented which assertions fail without the pull request's ConsoleReader change.

``` javascript
    @Test
    public void testNumericExpansions() throws Exception {
        ConsoleReader reader = new ConsoleReader();
        MemoryHistory history = new MemoryHistory();
        history.setMaxSize(3);

        // Seed history with three entries:
        // 1 history1
        // 2 history2
        // 3 history3
        history.add("history1");
        history.add("history2");
        history.add("history3");
        reader.setHistory(history);

        // Validate !n
        assertExpansionIllegalArgumentException(reader, "!0");  // fail
        assertEquals("history1", reader.expandEvents("!1"));    // fail
        assertEquals("history2", reader.expandEvents("!2"));    // fail
        assertEquals("history3", reader.expandEvents("!3"));    // fail
        assertExpansionIllegalArgumentException(reader, "!4");

        // Validate !-n
        assertExpansionIllegalArgumentException(reader, "!-0"); // fail
        assertEquals("history3", reader.expandEvents("!-1"));
        assertEquals("history2", reader.expandEvents("!-2"));
        assertEquals("history1", reader.expandEvents("!-3"));   // fail
        assertExpansionIllegalArgumentException(reader, "!-4");

        // Validate !!
        assertEquals("history3", reader.expandEvents("!!"));

        // Add two new entries. Because maxSize=3, history is:
        // 3 history3
        // 4 history4
        // 5 history5
        history.add("history4");
        history.add("history5");

        // Validate !n
        assertExpansionIllegalArgumentException(reader, "!0");
        assertExpansionIllegalArgumentException(reader, "!1");
        assertExpansionIllegalArgumentException(reader, "!2");  // fail
        assertEquals("history3", reader.expandEvents("!3"));    // fail
        assertEquals("history4", reader.expandEvents("!4"));    // fail
        assertEquals("history5", reader.expandEvents("!5"));    // fail
        assertExpansionIllegalArgumentException(reader, "!6");

        // Validate !-n
        assertExpansionIllegalArgumentException(reader, "!-0"); // fail
        assertEquals("history5", reader.expandEvents("!-1"));
        assertEquals("history4", reader.expandEvents("!-2"));
        assertEquals("history3", reader.expandEvents("!-3"));   // fail
        assertExpansionIllegalArgumentException(reader, "!-4");

        // Validate !!
        assertEquals("history5", reader.expandEvents("!!"));
    }
```
