### PR TITLE
Use the same default arrows as readline

### DIFF
--- a/src/main/java/jline/console/KeyMap.java
+++ b/src/main/java/jline/console/KeyMap.java
@@ -180,12 +180,12 @@ public class KeyMap {
         bind( map, "\033[H", Operation.BEGINNING_OF_LINE );
         bind( map, "\033[F", Operation.END_OF_LINE );
 
-        bind( map, "\033[OA", Operation.PREVIOUS_HISTORY );
-        bind( map, "\033[OB", Operation.NEXT_HISTORY );
-        bind( map, "\033[OC", Operation.FORWARD_CHAR );
-        bind( map, "\033[OD", Operation.BACKWARD_CHAR );
-        bind( map, "\033[OH", Operation.BEGINNING_OF_LINE );
-        bind( map, "\033[OF", Operation.END_OF_LINE );
+        bind( map, "\033OA", Operation.PREVIOUS_HISTORY );
+        bind( map, "\033OB", Operation.NEXT_HISTORY );
+        bind( map, "\033OC", Operation.FORWARD_CHAR );
+        bind( map, "\033OD", Operation.BACKWARD_CHAR );
+        bind( map, "\033OH", Operation.BEGINNING_OF_LINE );
+        bind( map, "\033OF", Operation.END_OF_LINE );
 
         bind( map, "\033[3~", Operation.DELETE_CHAR);
 


### PR DESCRIPTION
This should make it so people don't encounter things like #54 / technomancy/leiningen#997 Readline itself hard-codes in arrow key behavior (why? no idea.), and so sometimes default `inputrc` files will leave these keybindings out.

I think maybe the additional `[` was just a typo in the original commit, jline/jline2@f728bf8e (search "OH" on that commit; I wasn't able to find a way to link directly to the line), since the other settings are all properly carried over from readline. @gnodet can you confirm?

See http://git.savannah.gnu.org/cgit/readline.git/tree/readline.c?id=9922d2d7608ea86ff9e42aca0d3342a92748873f#n1128 for the readline implementation.

This works for my default Ubuntu install with no inputrc modifications.
