### PR TITLE
Don't print newline on UnixTerminal exit

### DIFF
--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -64,9 +64,6 @@ public class UnixTerminal
     public void restore() throws Exception {
         settings.restore();
         super.restore();
-        // print a newline after the terminal exits.
-        // this should probably be a configurable.
-        System.out.println();
     }
 
     /**


### PR DESCRIPTION
Other unix readline-using programs (e.g. bash, mysql, psql, bash) don't
appear to do this.

There was some confusion about this on the mailing list (https://groups.google.com/forum/?fromgroups=#!topic/jline-users/kf4Ek77j_iQ%5B1-25-false%5D), and I'm looking to get rid of it to allow turning jline on and off in the context of a command-line app.

Would be happy to add a configuration instead on this PR, or to go ahead and merge this myself - just let me know.
