### PR TITLE
Allow custom InputStreamReader to read non-BMP

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -2233,10 +2233,10 @@ public class ConsoleReader
                 if (c == -1) {
                     return null;
                 }
-                sb.append( (char) c );
+                sb.appendCodePoint(c);
 
                 if (recording) {
-                    macro += (char) c;
+                    macro += new String(new int[]{c}, 0, 1);
                 }
 
                 Object o = getKeys().getBound( sb );

--- a/src/main/java/jline/internal/InputStreamReader.java
+++ b/src/main/java/jline/internal/InputStreamReader.java
@@ -28,7 +28,9 @@ import java.nio.charset.UnmappableCharacterException;
  * NOTE for JLine: the default InputStreamReader that comes from the JRE
  * usually read more bytes than needed from the input stream, which
  * is not usable in a character per character model used in the console.
- * We thus use the harmony code which only reads the minimal number of bytes.
+ * We thus use the harmony code which only reads the minimal number of bytes,
+ * with a modification to ensure we can read larger characters (UTF-16 has
+ * up to 4 bytes, and UTF-32, rare as it is, may have up to 8).
  */
 /**
  * A class for turning a byte stream into a character stream. Data read from the
@@ -192,8 +194,8 @@ public class InputStreamReader extends Reader {
                 throw new IOException("InputStreamReader is closed.");
             }
 
-            char buf[] = new char[1];
-            return read(buf, 0, 1) != -1 ? buf[0] : -1;
+            char buf[] = new char[4];
+            return read(buf, 0, 4) != -1 ? Character.codePointAt(buf, 0) : -1;
         }
     }
 


### PR DESCRIPTION
These multiple-char characters were causing EOFs to propagate before the
input was complete.

e.g. http://www.fileformat.info/info/unicode/char/10330/index.htm

Originally reported in https://github.com/trptcolin/reply/issues/104

There's further work that would be nice to do, like making non-BMP characters only take up 1 slot in the buffer for motions like arrow keys / backspaces - but a quick glance suggests that'll take much more work.
