### PR TITLE
Add method to print lines with optional pagination

### DIFF
--- a/src/test/java/jline/console/completer/WhitespaceDelimiterTest.java
+++ b/src/test/java/jline/console/completer/WhitespaceDelimiterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2012, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package jline.console.completer;
+
+import static org.junit.Assert.assertArrayEquals;
+import jline.console.ConsoleReaderTestSupport;
+import jline.console.completer.ArgumentCompleter.ArgumentList;
+import jline.console.completer.ArgumentCompleter.WhitespaceArgumentDelimiter;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link WhitespaceArgumentDelimiter}.
+ * 
+ * @author <a href="mailto:mdrob@apache.org">Mike Drob</a>
+ */
+public class WhitespaceDelimiterTest extends ConsoleReaderTestSupport {
+
+  ArgumentList delimited;
+  WhitespaceArgumentDelimiter delimiter;
+
+  @Before
+  public void setUp() {
+    delimiter = new WhitespaceArgumentDelimiter();
+  }
+
+  @Test
+  public void testDelimit() {
+    // These all passed before adding quoting and escaping
+    delimited = delimiter.delimit("1 2 3", 0);
+    assertArrayEquals(new String[] {"1", "2", "3"}, delimited.getArguments());
+
+    delimited = delimiter.delimit("1  2  3", 0);
+    assertArrayEquals(new String[] {"1", "2", "3"}, delimited.getArguments());
+  }
+
+  @Test
+  public void testQuotedDelimit() {
+    delimited = delimiter.delimit("\"1 2\" 3", 0);
+    assertArrayEquals(new String[] {"1 2", "3"}, delimited.getArguments());
+
+    delimited = delimiter.delimit("'1 2' 3", 0);
+    assertArrayEquals(new String[] {"1 2", "3"}, delimited.getArguments());
+
+    delimited = delimiter.delimit("1 '2 3'", 0);
+    assertArrayEquals(new String[] {"1", "2 3"}, delimited.getArguments());
+  }
+
+  @Test
+  public void testMixedQuotes() {
+    delimited = delimiter.delimit("\"1' '2\" 3", 0);
+    assertArrayEquals(new String[] {"1' '2", "3"}, delimited.getArguments());
+
+    delimited = delimiter.delimit("'1\" 2' 3\"", 0);
+    assertArrayEquals(new String[] {"1\" 2", "3"}, delimited.getArguments());
+  }
+
+  @Test
+  public void testEscapedSpace() {
+    delimited = delimiter.delimit("1\\ 2 3", 0);
+    assertArrayEquals(new String[] {"1 2", "3"}, delimited.getArguments());
+  }
+
+  @Test
+  public void testEscapedQuotes() {
+    delimited = delimiter.delimit("'1 \\'2' 3", 0);
+    assertArrayEquals(new String[] {"1 '2", "3"}, delimited.getArguments());
+
+    delimited = delimiter.delimit("\\'1 '2' 3", 0);
+    assertArrayEquals(new String[] {"'1", "2", "3"}, delimited.getArguments());
+
+    delimited = delimiter.delimit("'1 '2\\' 3", 0);
+    assertArrayEquals(new String[] {"1 ", "2'", "3"}, delimited.getArguments());
+  }
+}


### PR DESCRIPTION
The `ConsoleReader.printColumns()` method is great for formatted columnar output (similar to that of `ls`), but it has a few shortcomings. First, it must scan through the entire input, which may be very expensive based on size. Second, it does not allow a user to specify a single column output, but still take advantage of the pagination setting available. This patch addresses both of those limitations.
