### PR TITLE
Support for !$ (args history expansion )

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -680,6 +680,18 @@ public class ConsoleReader
                                     rep = history.get(idx).toString();
                                 }
                                 break;
+                            case '$':
+                                if (history.size() == 0) {
+                                    throw new IllegalArgumentException("!#: event not found");
+                                }
+                                String previous = history.get(history.index() - 1).toString().trim();
+                                int lastSpace = previous.lastIndexOf(' ');
+                                if(lastSpace != -1) {
+                                    rep = previous.substring(lastSpace+1);
+                                } else {
+                                    rep = previous;
+                                }
+                                break;
                             case ' ':
                             case '\t':
                                 sb.append('!');

--- a/src/test/java/jline/console/ConsoleReaderTest.java
+++ b/src/test/java/jline/console/ConsoleReaderTest.java
@@ -351,6 +351,38 @@ public class ConsoleReaderTest
         assertEquals("history5", reader.expandEvents("!!"));
     }
 
+    @Test
+    public void testArgsExpansion() throws Exception {
+        ConsoleReader reader = createConsole();
+        MemoryHistory history = new MemoryHistory();
+        history.setMaxSize(3);
+        reader.setHistory(history);
+
+        // we can't go back to previous arguments if there are none
+        try {
+            reader.expandEvents("!$");
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("!#: event not found", e.getMessage());
+        }
+
+        // if no arguments were given, it should expand to the command itself
+        history.add("ls");
+        assertEquals("ls", reader.expandEvents("!$"));
+
+        // now we can expand to the last argument
+        history.add("ls /home");
+        assertEquals("/home", reader.expandEvents("!$"));
+
+        //we always take the last argument
+        history.add("ls /home /etc");
+        assertEquals("/etc", reader.expandEvents("!$"));
+
+        //make sure we don't add spaces accidentally
+        history.add("ls /home  /foo ");
+        assertEquals("/foo", reader.expandEvents("!$"));
+    }
+
 	/**
 	 * Validates that an 'event not found' IllegalArgumentException is thrown
 	 * for the expansion event.


### PR DESCRIPTION
Support for bash style arguments history expansion. 

For example:

When you just entered: 

```
ls some_dir
```

And then enter

```
rm !$ 
```

the command gets expanded to

```
rm some_dir
```

See the ref at http://www.gnu.org/software/bash/manual/bashref.html
This pull request only has support for the short form, if wanted, I can look at supporting the long form.

This was inspired by a jira issue at Karaf ( https://issues.apache.org/jira/browse/KARAF-2070 )
