### PR TITLE
Drop use of ThreadLocal, which causes class loader leaks.

### DIFF
--- a/src/main/java/jline/TerminalFactory.java
+++ b/src/main/java/jline/TerminalFactory.java
@@ -42,7 +42,7 @@ public class TerminalFactory
 
     public static final String FALSE = "false";
 
-    private static final InheritableThreadLocal<Terminal> holder = new InheritableThreadLocal<Terminal>();
+    private static Terminal term = null;
 
     public static synchronized Terminal create() {
         if (Log.TRACE) {
@@ -109,11 +109,11 @@ public class TerminalFactory
     }
 
     public static synchronized void reset() {
-        holder.remove();
+        term = null;
     }
 
     public static synchronized void resetIf(final Terminal t) {
-        if (holder.get() == t) {
+        if(t == term) {
             reset();
         }
     }
@@ -154,12 +154,10 @@ public class TerminalFactory
     }
 
     public static synchronized Terminal get() {
-        Terminal t = holder.get();
-        if (t == null) {
-            t = create();
-            holder.set(t);
+        if (term == null) {
+            term = create();
         }
-        return t;
+        return term;
     }
 
     public static Terminal getFlavor(final Flavor flavor) throws Exception {


### PR DESCRIPTION
This reverts the main part of 0c6089be9dad12bd5902b0a54591319885cafd47.  The reason for using a ThreadLocal isn't given in the original commit.  The terminal is a global resource and the use of ThreadLocal causes class loader leaks, so this pull request removes the ThreadLocal.
