### PR TITLE
Correctly parse LC_CTYPE when a modifier is present

### DIFF
--- a/src/main/java/jline/internal/Configuration.java
+++ b/src/main/java/jline/internal/Configuration.java
@@ -203,12 +203,37 @@ public class Configuration
         return System.getProperty("file.encoding");
     }
 
+    /**
+     * Get the default encoding.  Will first look at the LC_CTYPE environment variable, then the input.encoding
+     * system property, then the default charset according to the JVM.
+     *
+     * @return The default encoding to use when none is specified.
+     */
     public static String getEncoding() {
         // LC_CTYPE is usually in the form en_US.UTF-8
-        String ctype = System.getenv("LC_CTYPE");
-        if (ctype != null && ctype.indexOf('.') > 0) {
-            return ctype.substring(ctype.indexOf('.') + 1);
+        String envEncoding = extractEncodingFromCtype(System.getenv("LC_CTYPE"));
+        if (envEncoding != null) {
+            return envEncoding;
         }
         return System.getProperty("input.encoding", Charset.defaultCharset().name());
+    }
+
+    /**
+     * Parses the LC_CTYPE value to extract the encoding according to the POSIX standard, which says that the LC_CTYPE
+     * environment variable may be of the format <code>[language[_territory][.codeset][@modifier]]</code>
+     *
+     * @param ctype The ctype to parse, may be null
+     * @return The encoding, if one was present, otherwise null
+     */
+    static String extractEncodingFromCtype(String ctype) {
+        if (ctype != null && ctype.indexOf('.') > 0) {
+            String encodingAndModifier = ctype.substring(ctype.indexOf('.') + 1);
+            if (encodingAndModifier.indexOf('@') > 0) {
+                return encodingAndModifier.substring(0, encodingAndModifier.indexOf('@'));
+            } else {
+                return encodingAndModifier;
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/jline/internal/ConfigurationTest.java
+++ b/src/test/java/jline/internal/ConfigurationTest.java
@@ -8,10 +8,9 @@
  */
 package jline.internal;
 
-import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link Configuration}.
@@ -59,4 +58,36 @@ public class ConfigurationTest
         String value2 = Configuration.getString("c");
         assertEquals("d", value2);
     }
+
+    @Test
+    public void parseCtypeNull() {
+        assertNull(Configuration.extractEncodingFromCtype(null));
+    }
+
+    @Test
+    public void parseCtypeBlank() {
+        assertNull(Configuration.extractEncodingFromCtype(""));
+    }
+
+    @Test
+    public void parseCtypeNoEncoding() {
+        assertNull(Configuration.extractEncodingFromCtype("fr_FR"));
+    }
+
+    @Test
+    public void parseCtypeNoEncodingWithModifier() {
+        assertNull(Configuration.extractEncodingFromCtype("fr_FR@euro"));
+    }
+
+    @Test
+    public void parseCtypeWithEncoding() {
+        assertEquals("UTF-8", Configuration.extractEncodingFromCtype("fr_FR.UTF-8"));
+    }
+
+    @Test
+    public void parseCtypeWithEncodingAndModifier() {
+        assertEquals("UTF-8", Configuration.extractEncodingFromCtype("fr_FR.UTF-8@euro"));
+    }
+
+
 }


### PR DESCRIPTION
The POSIX standard says the format for `LC_CTYPE` is:

```
[language[_territory][.codeset][@modifier]]
```

This ensures that the modifer is removed if present when the encoding is parsed from the `LC_CTYPE` environment variable.  For example, `fr_FR.utf-8@euro` is a valid `LC_CTYPE`, but currently the `getEncoding` method returns `utf-8@euro`.

See the POSIX standard for more details:

http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
