### PR TITLE
stty command using -F instead of the redirection

### DIFF
--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -165,7 +165,7 @@ public final class TerminalLineSettings
 
     private String stty(final String args) throws IOException, InterruptedException {
         checkNotNull(args);
-        return exec(String.format("%s %s < /dev/tty", sttyCommand, args));
+        return exec(String.format("%s -F /dev/tty %s ", sttyCommand, args));
     }
 
     private String exec(final String cmd) throws IOException, InterruptedException {


### PR DESCRIPTION
http://stackoverflow.com/questions/15348538/eclipse-hangs-when-run-application-application-runs-fine-eclipse-is-what-hangs

Disclaimer: The above post is not authored by me, it is mentioned here because I had the similar issue. I fixed it with a small change which is part of this pull request. 
