### PR TITLE
Swallowed InterruptedException with jline.internal.TerminalLineSettings ...

### DIFF
--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -97,6 +97,9 @@ public class UnixTerminal
             super.setEchoEnabled(enabled);
         }
         catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             Log.error("Failed to ", (enabled ? "enable" : "disable"), " echo", e);
         }
     }

--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -94,7 +94,10 @@ public final class TerminalLineSettings
             }
             return this.getProperty(name, config);
         } catch (Exception e) {
-            Log.warn("Failed to query stty ", name, e);            
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            Log.warn("Failed to query stty ", name, e);
             return -1;
         }
     }


### PR DESCRIPTION
...stty method

Sometimes the InterruptedException thrown by stty method of TerminalLineSettings is handled correctly and sometimes ignored which causes issues in the CRaSH project standalone mode (crashub.org) such as the getWidth() terminal facility. As result the thread interrupted status is lost!

Here is a pull request that fixes issues.
