### PR TITLE
Reset history position on user interrupt

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -2560,6 +2560,7 @@ public class ConsoleReader
                                     flush();
                                     String partialLine = buf.buffer.toString();
                                     buf.clear();
+                                    history.moveToEnd();
                                     throw new UserInterruptException(partialLine);
                                 }
                                 break;


### PR DESCRIPTION
When the user presses ctrl-C, the history position should be
reset to the end in order to match the behavior of readline.
