### PR TITLE
Change windows tests to use Assume

### DIFF
--- a/src/test/java/jline/console/ConsoleReaderTest.java
+++ b/src/test/java/jline/console/ConsoleReaderTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import static jline.console.ConsoleReaderTest.WindowsKey.*;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 
 /**
  * Tests for the {@link ConsoleReader}.
@@ -116,9 +117,7 @@ public class ConsoleReaderTest
     @Test
     public void testDeleteOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             'S', 's',
@@ -133,9 +132,7 @@ public class ConsoleReaderTest
     @Test
     public void testNumpadDeleteOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             'S', 's',
@@ -150,9 +147,7 @@ public class ConsoleReaderTest
     @Test
     public void testHomeKeyOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             'S', 's',
@@ -166,9 +161,7 @@ public class ConsoleReaderTest
     @Test
     public void testEndKeyOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             'S', 's',
@@ -183,9 +176,7 @@ public class ConsoleReaderTest
     @Test
     public void testPageUpOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             (char) SPECIAL_KEY_INDICATOR.code,
@@ -197,9 +188,7 @@ public class ConsoleReaderTest
     @Test
     public void testPageDownOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             (char) SPECIAL_KEY_INDICATOR.code,
@@ -211,9 +200,7 @@ public class ConsoleReaderTest
     @Test
     public void testEscapeOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             's', 's', 's',
@@ -226,9 +213,7 @@ public class ConsoleReaderTest
     @Test
     public void testInsertOnWindowsTerminal() throws Exception {
         // test only works on Windows
-        if (!(TerminalFactory.get() instanceof WindowsTerminal)) {
-            return;
-        }
+        assumeTrue(TerminalFactory.get() instanceof WindowsTerminal);
 
         char[] characters = new char[]{
             'o', 'p', 's',


### PR DESCRIPTION
It might be a good idea to use junit.Assume when checking for a Windows terminal in the unit tests instead of just returning. This will mark the tests as ignored when they are not actually run, and more clearly indicate that they were not applicable, instead of giving false assurances that all of the tests pass.
