### PR TITLE
Make history-search-backward/forward similar to readline's version.

### DIFF
--- a/src/main/java/jline/console/CursorBuffer.java
+++ b/src/main/java/jline/console/CursorBuffer.java
@@ -106,6 +106,14 @@ public class CursorBuffer
         return true;
     }
 
+    public String upToCursor() {
+        if (cursor <= 0) {
+            return "";
+        }
+
+        return buffer.substring(0, cursor);
+    }
+
     @Override
     public String toString() {
         return buffer.toString();

--- a/src/test/java/jline/console/history/HistoryTest.java
+++ b/src/test/java/jline/console/history/HistoryTest.java
@@ -9,6 +9,7 @@
 package jline.console.history;
 
 import jline.console.ConsoleReaderTestSupport;
+import jline.console.KeyMap;
 import org.junit.Test;
 
 import static jline.console.Operation.*;
@@ -73,5 +74,65 @@ public class HistoryTest
         assertBuffer("XXXtest line 4", b = b.op(ACCEPT_LINE).op(PREVIOUS_HISTORY));
         assertBuffer("XXXtest line 4", b = b.op(ACCEPT_LINE).op(PREVIOUS_HISTORY));
         assertBuffer("XXXtest line 4", b = b.op(ACCEPT_LINE).op(PREVIOUS_HISTORY));
+    }
+
+    @Test
+    public void testHistorySearchBackwardAndForward() throws Exception {
+        KeyMap map = console.getKeys();
+
+        // Map in HISTORY_SEARCH_BACKWARD.
+        map.bind("\033[0A", HISTORY_SEARCH_BACKWARD);
+        map.bind("\033[0B", HISTORY_SEARCH_FORWARD);
+
+        Buffer b = new Buffer().
+            append("toes").op(ACCEPT_LINE).
+            append("the quick brown").op(ACCEPT_LINE).
+            append("fox jumps").op(ACCEPT_LINE).
+            append("over the").op(ACCEPT_LINE).
+            append("lazy dog").op(ACCEPT_LINE).
+            append("");
+
+        assertBuffer("", b);
+
+        // Using history-search-backward behaves like previous-history when
+        // no input has been provided.
+        assertBuffer("lazy dog", b = b.append("\033[0A"));
+        assertBuffer("over the", b = b.append("\033[0A"));
+        assertBuffer("fox jumps", b = b.append("\033[0A"));
+
+        // history-search-forward should behave line next-history when no
+        // input has been provided.
+        assertBuffer("over the", b = b.append("\033[0B"));
+        assertBuffer("lazy dog", b = b.append("\033[0B"));
+        assertBuffer("", b = b.append("\033[0B"));
+
+        // Make sure we go back correctly.
+        assertBuffer("lazy dog", b = b.append("\033[0A"));
+        assertBuffer("over the", b = b.append("\033[0A"));
+        assertBuffer("fox jumps", b = b.append("\033[0A"));
+
+        // Search forward on 'l'.
+        b = b.append("l");
+        assertBuffer("lazy dog", b = b.append("\033[0B"));
+
+        // Try moving forward again.  We should be at our original input line,
+        // which is just a plain 'l' at this point.
+        assertBuffer("l", b = b.append("\033[0B"));
+
+        // Now we should have more context and history-search-backward should
+        // take us to "the quick brown" line.
+        b = b.op(BACKWARD_DELETE_CHAR).append("t");
+        assertBuffer("the quick brown", b = b.append("\033[0A"));
+
+        // Try moving backward again.
+        assertBuffer("toes", b = b.append("\033[0A"));
+
+        assertBuffer("the quick brown", b = b.append("\033[0B"));
+
+        b = b.op(BACKWARD_DELETE_CHAR);
+        assertBuffer("fox jumps", b = b.append("\033[0B"));
+
+        b = b.append("to");
+        assertBuffer("toes", b = b.append("\033[0A"));
     }
 }


### PR DESCRIPTION
This more closely matches the behavior you get with bash/readline.
There is currently a small difference: bash will move the cursor to the
end of the line when you haven't typed any characters and invoke
history-search-backward.  Readline will then remember you haven't typed
anything and continue to do the equivalent of previous-history.

This version leaves the cursor at the beginning of the line since it
would require extra state to determine whether or not characters have
been input or the cursor has been moved manually since the last
history-search-backward/forward.

For those that have history-search-backward and history-search-forward
in their ~/.inputrc files, this more closely matches the expected
behavior.
