### PR TITLE
Avoid passing null as the appName to ConsoleKeys.

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -230,7 +230,7 @@ public class ConsoleReader
 
         this.inputrcUrl = getInputRc();
 
-        consoleKeys = new ConsoleKeys(appName, inputrcUrl);
+        consoleKeys = new ConsoleKeys(this.appName, inputrcUrl);
     }
 
     private URL getInputRc() throws IOException {


### PR DESCRIPTION
The code above default this.appName to "JLine", but then appName is
passed directly to ConsoleKeys.  Instead, pass this.appName so that
ConsoleKeys can make use of the default "JLine" application name when
processing a user's ~/.inputrc file.
