### PR TITLE
Add support for vi '^' move to first printable

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -2876,6 +2876,10 @@ public class ConsoleReader
                                 }
                                 break;
 
+                            case VI_FIRST_PRINT:
+                                success = setCursorPosition(0) && viNextWord(1);
+                                break;
+
                             case VI_PREV_WORD:
                                 success = viPreviousWord(count);
                                 break;

--- a/src/test/java/jline/console/ViMoveModeTest.java
+++ b/src/test/java/jline/console/ViMoveModeTest.java
@@ -566,6 +566,16 @@ public class ViMoveModeTest
             .enter();
         assertLine("chicken sushimiicken sushimi", b, false);
     }
+
+    @Test
+    public void firstPrintable() throws Exception {
+      console.setKeyMap(KeyMap.VI_INSERT);
+      Buffer b = (new Buffer(" foo bar"))
+        .escape()
+        .append("^dw")
+        .enter();
+      assertLine(" bar", b, false);
+    }
     
     @Test
     public void testMatch() throws Exception {


### PR DESCRIPTION
The keymap already has the appropriate mapping, but no code was in place to move the cursor for that operation. I added that code and a test.
