### PR TITLE
fix: strict ArgumentCompleter completes on flawed first argument

### DIFF
--- a/src/test/java/jline/console/completer/ArgumentCompleterTest.java
+++ b/src/test/java/jline/console/completer/ArgumentCompleterTest.java
@@ -36,4 +36,24 @@ public class ArgumentCompleterTest
         assertBuffer("foo ba baz", new Buffer("foo b baz").left().left().left().left().tab());
         assertBuffer("foo foo baz", new Buffer("foo f baz").left().left().left().left().tab());
     }
+
+    @Test
+    public void testMultiple() throws Exception {
+        ArgumentCompleter argCompleter = new ArgumentCompleter(
+             new StringsCompleter("bar", "baz"),
+             new StringsCompleter("foo"),
+             new StringsCompleter("ree"));
+        console.addCompleter(argCompleter);
+
+        assertBuffer("bar foo ", new Buffer("bar f").tab());
+        assertBuffer("baz foo ", new Buffer("baz f").tab());
+        // co completion of 2nd arg in strict mode when 1st argument is not matched exactly
+        assertBuffer("ba f", new Buffer("ba f").tab());
+        assertBuffer("bar fo r", new Buffer("bar fo r").tab());
+
+        argCompleter.setStrict(false);
+        assertBuffer("ba foo ", new Buffer("ba f").tab());
+        assertBuffer("ba fo ree", new Buffer("ba fo r").tab());
+    }
+
 }


### PR DESCRIPTION
See the test case for an example. I believe the Argument Matcher should only match any consequent arguments if early arguments are exactly matched, meaning one of the candidates must match excatly the argument.

Sadly, I have no idea how to patch the ArgumentCompleter correctly to do so in all possible cases given the delimiter can be anything, and the candidates may have any kind of delimiter attached at the end.
The tests show the failure, they are not sufficient to validate a correct solution.