### PR TITLE
preserve stty settings

### DIFF
--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -43,12 +43,14 @@ public final class TerminalLineSettings
     private String shCommand;
 
     private String config;
+    private String initialConfig;
 
     private long configLastFetched;
 
     public TerminalLineSettings() throws IOException, InterruptedException {
         sttyCommand = Configuration.getString(JLINE_STTY, DEFAULT_STTY);
         shCommand = Configuration.getString(JLINE_SH, DEFAULT_SH);
+        initialConfig = get("-g").trim();
         config = get("-a");
         configLastFetched = System.currentTimeMillis();
 
@@ -65,7 +67,7 @@ public final class TerminalLineSettings
     }
 
     public void restore() throws IOException, InterruptedException {
-        set("sane");
+        set(initialConfig);
     }
 
     public String get(final String args) throws IOException, InterruptedException {


### PR DESCRIPTION
- saves and restores stty settings instead of overwriting them with
  sane

I think this should fix the problems discussed in https://github.com/trptcolin/reply/issues/117

Before this patch

```
java -cp target/jline-2.12-SNAPSHOT.jar:target/jline-2.12-SNAPSHOT-tests.jar jline.example.Example
```

would mutate the settings of `stty` and after this patch it does not.
