### PR TITLE
ConsoleRunner: Fix an UnsupportedOperationException in main

### DIFF
--- a/src/main/java/jline/console/internal/ConsoleRunner.java
+++ b/src/main/java/jline/console/internal/ConsoleRunner.java
@@ -37,7 +37,7 @@ public class ConsoleRunner
     // FIXME: This is really ugly... re-write this
 
     public static void main(final String[] args) throws Exception {
-        List<String> argList = Arrays.asList(args);
+        List<String> argList = new ArrayList(Arrays.asList(args));
         if (argList.size() == 0) {
             usage();
             return;


### PR DESCRIPTION
Hello.  I am trying to use jline2 with JDB so that the up arrow key will work properly when I am entering commands for JDB.
This was apparently possible with older versions of jline with the procedure is described here: http://stackoverflow.com/questions/13877802/text-navigation-in-jdb-not-working-in-bash/13877842#13877842

However, there is at least one problem in the ConsoleRunner class that makes this currently impossible.  To recreate the problem, I cloned jline2 to my Arch Linux machine, ran `mvn install`, and then I ran this command:

```
$ java -classpath target/jline-2.12-SNAPSHOT.jar jline.console.internal.ConsoleRunner abc
Exception in thread "main" java.lang.UnsupportedOperationException
        at java.util.AbstractList.remove(AbstractList.java:161)
        at jline.console.internal.ConsoleRunner.main(ConsoleRunner.java:48)
```

The problem is that ConsoleRunner is trying to modify a list of strings that was created using `Arrays.asList`.  This is not possible, as explained here:
http://stackoverflow.com/questions/7885573/remove-on-list-created-by-arrays-aslist-throws-unsupportedexception

After applying the fix presented in this pull request, the same command gets past the point where it was failing and gives a better error:

```
$ java -classpath target/jline-2.12-SNAPSHOT.jar jline.console.internal.ConsoleRunner abc
Exception in thread "main" java.lang.ClassNotFoundException: abc
        at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:190)
        at jline.console.internal.ConsoleRunner.main(ConsoleRunner.java:75)

```

I don't understand how ConsoleRunner ever worked.  Perhaps it was developed on a version of Java that behaves differently from the one I am using?  I am using the following JDK packages in Arch Linux:

```
$ pacman -Q | grep jdk
jdk7-openjdk 7.u51_2.4.4-1
jre7-openjdk 7.u51_2.4.4-1
jre7-openjdk-headless 7.u51_2.4.4-1
```

My editors (both emacs and nano) also added a newline to the end of the file.  Sorry, but I didn't think it was worthwhile to figure out how to avoid that.
