### PR TITLE
Restore rich completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.ipr
 *.iws
 target
+/.settings
+/.classpath
+/.project

--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -43,6 +43,7 @@ import jline.TerminalFactory;
 import jline.UnixTerminal;
 import jline.console.completer.CandidateListCompletionHandler;
 import jline.console.completer.Completer;
+import jline.console.completer.Completion;
 import jline.console.completer.CompletionHandler;
 import jline.console.history.History;
 import jline.console.history.MemoryHistory;
@@ -52,6 +53,7 @@ import jline.internal.Log;
 import jline.internal.NonBlockingInputStream;
 import jline.internal.Nullable;
 import jline.internal.Urls;
+
 import org.fusesource.jansi.AnsiOutputStream;
 
 import static jline.internal.Preconditions.checkNotNull;
@@ -3135,7 +3137,7 @@ public class ConsoleReader
             return false;
         }
 
-        List<CharSequence> candidates = new LinkedList<CharSequence>();
+        List<Completion> candidates = new LinkedList<Completion>();
         String bufstr = buf.buffer.toString();
         int cursor = buf.cursor;
 
@@ -3156,7 +3158,7 @@ public class ConsoleReader
             return;
         }
 
-        List<CharSequence> candidates = new LinkedList<CharSequence>();
+        List<Completion> candidates = new LinkedList<Completion>();
         String bufstr = buf.buffer.toString();
         int cursor = buf.cursor;
 

--- a/src/main/java/jline/console/completer/AggregateCompleter.java
+++ b/src/main/java/jline/console/completer/AggregateCompleter.java
@@ -64,19 +64,19 @@ public class AggregateCompleter
     /**
      * Perform a completion operation across all aggregated completers.
      *
-     * @see Completer#complete(String, int, java.util.List)
+     * @see Completer#complete(String, int, List)
      * @return the highest completion return value from all completers
      */
-    public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
+    public int complete(final String buffer, final int cursor, final List<Completion> candidates) {
         // buffer could be null
         checkNotNull(candidates);
 
-        List<Completion> completions = new ArrayList<Completion>(completers.size());
+        List<CompletionResult> completions = new ArrayList<CompletionResult>(completers.size());
 
         // Run each completer, saving its completion results
         int max = -1;
         for (Completer completer : completers) {
-            Completion completion = new Completion(candidates);
+            CompletionResult completion = new CompletionResult(candidates);
             completion.complete(completer, buffer, cursor);
 
             // Compute the max cursor position
@@ -86,7 +86,7 @@ public class AggregateCompleter
         }
 
         // Append candidates from completions which have the same cursor position as max
-        for (Completion completion : completions) {
+        for (CompletionResult completion : completions) {
             if (completion.cursor == max) {
                 candidates.addAll(completion.candidates);
             }
@@ -105,15 +105,15 @@ public class AggregateCompleter
             '}';
     }
 
-    private class Completion
+    private class CompletionResult
     {
-        public final List<CharSequence> candidates;
+        public final List<Completion> candidates;
 
         public int cursor;
 
-        public Completion(final List<CharSequence> candidates) {
+        public CompletionResult(final List<Completion> candidates) {
             checkNotNull(candidates);
-            this.candidates = new LinkedList<CharSequence>(candidates);
+            this.candidates = new LinkedList<Completion>(candidates);
         }
 
         public void complete(final Completer completer, final String buffer, final int cursor) {

--- a/src/main/java/jline/console/completer/ArgumentCompleter.java
+++ b/src/main/java/jline/console/completer/ArgumentCompleter.java
@@ -108,7 +108,7 @@ public class ArgumentCompleter
         return completers;
     }
 
-    public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
+    public int complete(final String buffer, final int cursor, final List<Completion> candidates) {
         // buffer can be null
         checkNotNull(candidates);
 
@@ -138,7 +138,7 @@ public class ArgumentCompleter
             String[] args = list.getArguments();
             String arg = (args == null || i >= args.length) ? "" : args[i];
 
-            List<CharSequence> subCandidates = new LinkedList<CharSequence>();
+            List<Completion> subCandidates = new LinkedList<Completion>();
 
             if (sub.complete(arg, arg.length(), subCandidates) == -1) {
                 return -1;
@@ -165,13 +165,13 @@ public class ArgumentCompleter
 
         if ((cursor != buffer.length()) && delim.isDelimiter(buffer, cursor)) {
             for (int i = 0; i < candidates.size(); i++) {
-                CharSequence val = candidates.get(i);
+            	CharSequence val = candidates.get(i).getValue();
 
                 while (val.length() > 0 && delim.isDelimiter(val, val.length() - 1)) {
                     val = val.subSequence(0, val.length() - 1);
                 }
 
-                candidates.set(i, val);
+                candidates.set(i, new Completion(val));
             }
         }
 

--- a/src/main/java/jline/console/completer/Completer.java
+++ b/src/main/java/jline/console/completer/Completer.java
@@ -34,5 +34,5 @@ public interface Completer
      * @param candidates    The {@link List} of candidates to populate
      * @return              The index of the <i>buffer</i> for which the completion will be relative
      */
-    int complete(String buffer, int cursor, List<CharSequence> candidates);
+    int complete(String buffer, int cursor, List<Completion> candidates);
 }

--- a/src/main/java/jline/console/completer/Completion.java
+++ b/src/main/java/jline/console/completer/Completion.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2014, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package jline.console.completer;
+
+import static jline.internal.Preconditions.checkNotNull;
+/**
+ * A completion proposal which, in addition to its actual value, can have:<ul>
+ * <li>a heading under which it may be categorized</li>
+ * <li>a display label, to be used as an alternative to the value when outputting to 
+ * the screen (<i>e.g.</i> to save screen space or apply ANSI effects)</li>
+ * </ul>
+ * 
+ * @author Eric Bottard
+ */
+public class Completion {
+	
+	private final CharSequence value;
+	
+	private final CharSequence heading;
+	
+	private final CharSequence label;
+
+	public Completion(CharSequence value, CharSequence heading,
+			CharSequence label) {
+		checkNotNull(value);
+		checkNotNull(label);
+		this.value = value;
+		this.heading = heading;
+		this.label = label;
+	}
+
+	public Completion(CharSequence value) {
+		this(value, null, value);
+	}
+
+	public CharSequence getValue() {
+		return value;
+	}
+
+	public CharSequence getHeading() {
+		return heading;
+	}
+
+	public CharSequence getLabel() {
+		return label;
+	}
+	
+	
+
+}

--- a/src/main/java/jline/console/completer/CompletionHandler.java
+++ b/src/main/java/jline/console/completer/CompletionHandler.java
@@ -22,5 +22,5 @@ import java.util.List;
  */
 public interface CompletionHandler
 {
-    boolean complete(ConsoleReader reader, List<CharSequence> candidates, int position) throws IOException;
+    boolean complete(ConsoleReader reader, List<Completion> candidates, int position) throws IOException;
 }

--- a/src/main/java/jline/console/completer/FileNameCompleter.java
+++ b/src/main/java/jline/console/completer/FileNameCompleter.java
@@ -47,7 +47,7 @@ public class FileNameCompleter
         OS_IS_WINDOWS = os.contains("windows");
     }
 
-    public int complete(String buffer, final int cursor, final List<CharSequence> candidates) {
+    public int complete(String buffer, final int cursor, final List<Completion> candidates) {
         // buffer can be null
         checkNotNull(candidates);
 
@@ -102,7 +102,7 @@ public class FileNameCompleter
         return new File(".");
     }
 
-    protected int matchFiles(final String buffer, final String translated, final File[] files, final List<CharSequence> candidates) {
+    protected int matchFiles(final String buffer, final String translated, final File[] files, final List<Completion> candidates) {
         if (files == null) {
             return -1;
         }
@@ -118,7 +118,7 @@ public class FileNameCompleter
         for (File file : files) {
             if (file.getAbsolutePath().startsWith(translated)) {
                 CharSequence name = file.getName() + (matches == 1 && file.isDirectory() ? separator() : " ");
-                candidates.add(render(file, name).toString());
+                candidates.add(render(file, name));
             }
         }
 
@@ -127,7 +127,7 @@ public class FileNameCompleter
         return index + separator().length();
     }
 
-    protected CharSequence render(final File file, final CharSequence name) {
-        return name;
+    protected Completion render(final File file, final CharSequence name) {
+        return new Completion(name);
     }
 }

--- a/src/main/java/jline/console/completer/NullCompleter.java
+++ b/src/main/java/jline/console/completer/NullCompleter.java
@@ -22,7 +22,7 @@ public final class NullCompleter
 {
     public static final NullCompleter INSTANCE = new NullCompleter();
 
-    public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
+    public int complete(final String buffer, final int cursor, final List<Completion> candidates) {
         return -1;
     }
 }

--- a/src/main/java/jline/console/completer/StringsCompleter.java
+++ b/src/main/java/jline/console/completer/StringsCompleter.java
@@ -44,25 +44,22 @@ public class StringsCompleter
         return strings;
     }
 
-    public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
+    public int complete(final String buffer, final int cursor, final List<Completion> candidates) {
         // buffer could be null
         checkNotNull(candidates);
 
-        if (buffer == null) {
-            candidates.addAll(strings);
-        }
-        else {
-            for (String match : strings.tailSet(buffer)) {
-                if (!match.startsWith(buffer)) {
-                    break;
-                }
+        String prefix = buffer == null ? "" : buffer;
+		for (String match : strings.tailSet(prefix)) {
+			if (!match.startsWith(prefix)) {
+				break;
+			}
 
-                candidates.add(match);
-            }
-        }
+			candidates.add(new Completion(match));
+		}
 
         if (candidates.size() == 1) {
-            candidates.set(0, candidates.get(0) + " ");
+        	CharSequence value = candidates.get(0).getValue(); 
+			candidates.set(0, new Completion(value + " "));
         }
 
         return candidates.isEmpty() ? -1 : 0;


### PR DESCRIPTION
Adds support for #130.

Completion.getHeading() is not used, so can be removed (and added later as a separate PR).

Passes all existing tests, will try to exercise it with real project soon