### PR TITLE
fix issue #140 #141 : Windows console output codepage to java charset: prefer 'msNNN' to 'cpNNN'

### DIFF
--- a/src/main/java/jline/WindowsTerminal.java
+++ b/src/main/java/jline/WindowsTerminal.java
@@ -184,7 +184,17 @@ public class WindowsTerminal
     @Override
     public String getOutputEncoding() {
         int codepage = getConsoleOutputCodepage();
-        return "cp" + codepage;
+        //http://docs.oracle.com/javase/6/docs/technotes/guides/intl/encoding.doc.html
+        String charsetMS = "ms" + codepage;
+        if (java.nio.charset.Charset.isSupported(charsetMS)) {
+            return charsetMS;
+        }
+        String charsetCP = "cp" + codepage;
+        if (java.nio.charset.Charset.isSupported(charsetCP)) {
+            return charsetCP;
+        }
+        Log.debug("can't figure out the Java Charset of this code page (" + codepage + ")...");
+        return super.getOutputEncoding();
     }
 
     //


### PR DESCRIPTION
To output java's unicode string we need to encode it according to Windows console's codepage(which may not be the same as jvm's default charset), but there is no well defined mapping between Windows codepage and Java charset, expect this tweak works for most locales.
