### PR TITLE
fix issue #144: let Windows support ALT+X keys.

### DIFF
--- a/src/main/java/jline/WindowsTerminal.java
+++ b/src/main/java/jline/WindowsTerminal.java
@@ -225,6 +225,14 @@ public class WindowsTerminal
             //Log.trace(keyEvent.keyDown? "KEY_DOWN" : "KEY_UP", "key code:", keyEvent.keyCode, "char:", (long)keyEvent.uchar); 
             if (keyEvent.keyDown) {
                 if (keyEvent.uchar > 0) {
+                    // support some C1 control sequences: ALT + [@-_] (and [a-z]?) => ESC <ascii>
+                    // http://en.wikipedia.org/wiki/C0_and_C1_control_codes#C1_set
+                    int altState = KEY_EVENT_RECORD.LEFT_ALT_PRESSED | KEY_EVENT_RECORD.RIGHT_ALT_PRESSED;
+                    if (((keyEvent.uchar >= '@' && keyEvent.uchar <= '_') || (keyEvent.uchar >= 'a' && keyEvent.uchar <= 'z'))
+                        && (keyEvent.controlKeyState & altState) != 0) {
+                        sb.append('\u001B'); // ESC
+                    }
+
                     sb.append(keyEvent.uchar);
                     continue;
                 }


### PR DESCRIPTION
Convert ALT+[@-_] inputs to 'ESC  <ascii>' sequence, as defined by C1 ANSI Control Sequence:
http://en.wikipedia.org/wiki/C0_and_C1_control_codes#C1_set
ALT+[a-z](that is, ALT + SHIFT + [A-Z] ?) seems not specified, but linux & jline handle them same as ALT + [A-Z], so I also included these keys.
