### PR TITLE
Fix stty parsing on HP/UX

### DIFF
--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -115,7 +115,7 @@ public final class TerminalLineSettings
      */
     protected static int getProperty(String name, String stty) {
         // try the first kind of regex
-        Pattern pattern = Pattern.compile(name + "\\s+=\\s+([^;]*)[;\\n\\r]");
+        Pattern pattern = Pattern.compile(name + "\\s+=\\s+(.*?)[;\\n\\r]");
         Matcher matcher = pattern.matcher(stty);
         if (!matcher.find()) {
             // try a second kind of regex

--- a/src/test/java/jline/internal/TerminalLineSettingsTest.java
+++ b/src/test/java/jline/internal/TerminalLineSettingsTest.java
@@ -98,6 +98,20 @@ public class TerminalLineSettingsTest
             "        lnext = ^V; min = 1; quit = ^\\; reprint = ^R; start = ^Q;\n" +
             "        status = ^T; stop = ^S; susp = ^Z; time = 0; werase = ^W;";
 
+    private final String hpuxSttySample = "speed 38400 baud; line = 0;\n" +
+            "rows = 52; columns = 151\n" +
+            "min = 4; time = 0;\n" +
+            "intr = DEL; quit = ^\\; erase = #; kill = @\n" +
+            "eof = ^D; eol = ^@; eol2 <undef>; swtch = ^@\n" +
+            "stop = ^S; start = ^Q; susp <undef>; dsusp <undef>\n" +
+            "werase <undef>; lnext <undef>\n" +
+            "-parenb -parodd cs8 -cstopb hupcl cread -clocal -loblk -crts\n" +
+            "-ignbrk brkint ignpar -parmrk -inpck istrip -inlcr -igncr icrnl -iuclc\n" +
+            "ixon ixany -ixoff -imaxbel -rtsxoff -ctsxon -ienqak\n" +
+            "isig icanon -iexten -xcase echo -echoe echok -echonl -noflsh\n" +
+            "-echoctl -echoprt -echoke -flusho -pendin\n" +
+            "opost -olcuc onlcr -ocrnl -onocr -onlret -ofill -ofdel -tostop";
+
     @Before
     public void setUp() throws Exception {
     }
@@ -151,6 +165,13 @@ public class TerminalLineSettingsTest
         assertEquals(0x7f, TerminalLineSettings.getProperty("erase", freeBsdSttySample));
         assertEquals(199, TerminalLineSettings.getProperty("columns", freeBsdSttySample));
         assertEquals(32, TerminalLineSettings.getProperty("rows", freeBsdSttySample));
+    }
+
+    @Test
+    public void testHpuxSttyParsing() {
+        assertEquals(0x23, TerminalLineSettings.getProperty("erase", hpuxSttySample));
+        assertEquals(151, TerminalLineSettings.getProperty("columns", hpuxSttySample));
+        assertEquals(52, TerminalLineSettings.getProperty("rows", hpuxSttySample));
     }
 
 }


### PR DESCRIPTION
A user reported a problem running Apache ServiceMix on HP/UX, cfr. https://issues.apache.org/jira/browse/SM-2300.  The root cause there seems to be a problem in parsing the output of `stty -a` on HP/UX.  This pull request adds a test for HP/UX `stty -a` output which reproduces this problem and also includes the fix required to get this working.
