### PR TITLE
Fix stty undef on HP-UX

### DIFF
--- a/src/main/java/jline/NoInterruptUnixTerminal.java
+++ b/src/main/java/jline/NoInterruptUnixTerminal.java
@@ -25,7 +25,7 @@ public class NoInterruptUnixTerminal
     @Override
     public void init() throws Exception {
         super.init();
-        getSettings().set("intr undef");
+        getSettings().undef("intr");
     }
 
     @Override

--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -52,7 +52,7 @@ public class UnixTerminal
         // Make sure we're distinguishing carriage return from newline.
         // Allow ctrl-s keypress to be used (as forward search)
         settings.set("-icanon min 1 -icrnl -inlcr -ixon");
-        settings.set("dsusp undef");
+        settings.undef("dsusp");
 
         setEchoEnabled(false);
     }
@@ -108,7 +108,7 @@ public class UnixTerminal
     public void disableInterruptCharacter()
     {
         try {
-            settings.set("intr undef");
+            settings.undef("intr");
         }
         catch (Exception e) {
             if (e instanceof InterruptedException) {

--- a/src/main/java/jline/internal/Configuration.java
+++ b/src/main/java/jline/internal/Configuration.java
@@ -197,6 +197,10 @@ public class Configuration
         return getOsName().startsWith("windows");
     }
 
+    public static boolean isHpux() {
+        return getOsName().startsWith("hp");
+    }
+
     // FIXME: Sort out use of property access of file.encoding in InputStreamReader, consolidate should configuration access here
 
     public static String getFileEncoding() {

--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -38,6 +38,15 @@ public final class TerminalLineSettings
 
     public static final String DEFAULT_SH = "sh";
 
+    private static final String UNDEFINED;
+    static {
+        if (Configuration.isHpux()) {
+            UNDEFINED = "^-";
+        } else {
+            UNDEFINED = "undef";
+        }
+    }
+
     private String sttyCommand;
 
     private String shCommand;
@@ -76,6 +85,10 @@ public final class TerminalLineSettings
 
     public void set(final String args) throws IOException, InterruptedException {
         stty(args);
+    }
+
+    public void undef(final String args) throws IOException, InterruptedException {
+        stty(String.format("%s %s", args, UNDEFINED));
     }
 
     /**


### PR DESCRIPTION
On HP-UX, the correct command for undef'ing a control character is {{stty <character> ^-}} instead of {{stty <character> undef}}.