### PR TITLE
Change artifactId from "jline" to "jline2", to allow coexistence with jline v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>jline</groupId>
     <artifactId>jline2</artifactId>
     <name>JLine2</name>
-    <version>2.10</version>
+    <version>2.11-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
I am working with multi-module projects, some of which use jline v1 (specifically, 0.9.94) and I want to upgrade others to jline v2 (specifically 2.10). Since you renamed packages and classes in the transition to jline v2, there is no clash there. But the maven coordinates are still {groupId: "jline", artifactId: "jline"}, so they can't co-exist.

In this pull request, I have changed the artifactId from "jline" to "jline2" and the name from "JLine" to "Jline2". The groupId is still "jline". This has allowed me to upgrade apache-hive-sqlline to use jline2, while Pig continues to use jline.

I have made a release of jline:jline2:2.10 at the http://conjars.org/jline/jline2 repository. Other than the name change, it is identical to your jline:jline:2.10.

It would be nice if future releases of jline 2.x used "jline2" as the artifactId, so please consider this pull request.
