### PR TITLE
Make TerminalLineSettings static

### DIFF
--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -28,14 +28,9 @@ import jline.internal.TerminalLineSettings;
 public class UnixTerminal
     extends TerminalSupport
 {
-    private final TerminalLineSettings settings = new TerminalLineSettings();
-
     public UnixTerminal() throws Exception {
         super(true);
-    }
-
-    protected TerminalLineSettings getSettings() {
-        return settings;
+        TerminalLineSettings.initialize();
     }
 
     /**
@@ -51,8 +46,8 @@ public class UnixTerminal
         // Set the console to be character-buffered instead of line-buffered.
         // Make sure we're distinguishing carriage return from newline.
         // Allow ctrl-s keypress to be used (as forward search)
-        settings.set("-icanon min 1 -icrnl -inlcr -ixon");
-        settings.set("dsusp undef");
+        TerminalLineSettings.set("-icanon min 1 -icrnl -inlcr -ixon");
+        TerminalLineSettings.set("dsusp undef");
 
         setEchoEnabled(false);
     }
@@ -64,7 +59,7 @@ public class UnixTerminal
      */
     @Override
     public void restore() throws Exception {
-        settings.restore();
+        TerminalLineSettings.restore();
         super.restore();
     }
 
@@ -73,7 +68,7 @@ public class UnixTerminal
      */
     @Override
     public int getWidth() {
-        int w = settings.getProperty("columns");
+        int w = TerminalLineSettings.getProperty("columns");
         return w < 1 ? DEFAULT_WIDTH : w;
     }
 
@@ -82,7 +77,7 @@ public class UnixTerminal
      */
     @Override
     public int getHeight() {
-        int h = settings.getProperty("rows");
+        int h = TerminalLineSettings.getProperty("rows");
         return h < 1 ? DEFAULT_HEIGHT : h;
     }
 
@@ -90,10 +85,10 @@ public class UnixTerminal
     public synchronized void setEchoEnabled(final boolean enabled) {
         try {
             if (enabled) {
-                settings.set("echo");
+                TerminalLineSettings.set("echo");
             }
             else {
-                settings.set("-echo");
+                TerminalLineSettings.set("-echo");
             }
             super.setEchoEnabled(enabled);
         }
@@ -108,7 +103,7 @@ public class UnixTerminal
     public void disableInterruptCharacter()
     {
         try {
-            settings.set("intr undef");
+            TerminalLineSettings.set("intr undef");
         }
         catch (Exception e) {
             if (e instanceof InterruptedException) {
@@ -121,7 +116,7 @@ public class UnixTerminal
     public void enableInterruptCharacter()
     {
         try {
-            settings.set("intr ^C");
+            TerminalLineSettings.set("intr ^C");
         }
         catch (Exception e) {
             if (e instanceof InterruptedException) {

--- a/src/test/java/jline/internal/TerminalLineSettingsTest.java
+++ b/src/test/java/jline/internal/TerminalLineSettingsTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertEquals;
  */
 public class TerminalLineSettingsTest
 {
-    private TerminalLineSettings settings;
-
     private final String linuxSttySample = "speed 38400 baud; rows 85; columns 244; line = 0;\n" +
             "intr = ^C; quit = ^\\; erase = ^?; kill = ^U; eof = ^D; eol = M-^?; eol2 = M-^?; swtch = M-^?; start = ^Q; stop = ^S; susp = ^Z; rprnt = ^R; werase = ^W; lnext = ^V; flush = ^O; min = 1; time = 0;\n" +
             "-parenb -parodd cs8 hupcl -cstopb cread -clocal -crtscts\n" +
@@ -119,8 +117,8 @@ public class TerminalLineSettingsTest
     @Test
     public void testGetConfig() throws Exception {
         if (!Configuration.getOsName().contains("win")) {
-            TerminalLineSettings settings = new TerminalLineSettings();
-            String config = settings.getConfig();
+            TerminalLineSettings.initialize();
+            String config = TerminalLineSettings.getConfig();
             System.out.println(config);
         }
     }


### PR DESCRIPTION
This change addresses issues like #163 and possibly other problems where jline2 would save it's own stty settings as though they were the ones it should be restoring later.