### PR TITLE
Term dumb inside emacs still allow ansi support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,27 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <version>3.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.5.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-easymock</artifactId>
+            <version>1.5.6</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/jline/TerminalFactory.java
+++ b/src/main/java/jline/TerminalFactory.java
@@ -52,12 +52,12 @@ public class TerminalFactory
 
         String type = Configuration.getString(JLINE_TERMINAL, AUTO);
         if ("dumb".equals(System.getenv("TERM"))) {
-            // emacs communicate with shell through a 'dumb' terminal
+            // emacs communicates with shell through a 'dumb' terminal
             // but sets these env variables to let programs know
             // it is ok to send ANSI control sequences
             String emacs = System.getenv("EMACS");
             String insideEmacs = System.getenv("INSIDE_EMACS");
-            if (!emacs && !insideEmacs) {
+            if (emacs == null || insideEmacs == null) {
                 type = "none";
                 Log.debug("$TERM=dumb; setting type=", type);
             }

--- a/src/main/java/jline/TerminalFactory.java
+++ b/src/main/java/jline/TerminalFactory.java
@@ -52,8 +52,15 @@ public class TerminalFactory
 
         String type = Configuration.getString(JLINE_TERMINAL, AUTO);
         if ("dumb".equals(System.getenv("TERM"))) {
-            type = "none";
-            Log.debug("$TERM=dumb; setting type=", type);
+            // emacs communicate with shell through a 'dumb' terminal
+            // but sets these env variables to let programs know
+            // it is ok to send ANSI control sequences
+            String emacs = System.getenv("EMACS");
+            String insideEmacs = System.getenv("INSIDE_EMACS");
+            if (!emacs && !insideEmacs) {
+                type = "none";
+                Log.debug("$TERM=dumb; setting type=", type);
+            }
         }
 
         Log.debug("Creating terminal; type=", type);


### PR DESCRIPTION
I was trying to write a `comint` mode for `grails` and I came up against this problem.

Emacs sets the `$TERM` to `"dumb"` but also sets `$INSIDE_EMACS` and `$EMACS` variables to let programs know that it is ok to send Ansi sequences.

Here is the output from `groovysh` inside and outside of emacs

## inside emacs

	groovy:000> insideEmacs = System.getenv("INSIDE_EMACS");
	===> 24.3.1,comint
	groovy:000> emacs = System.getenv("EMACS");
	===> t
	groovy:000> term = System.getenv("TERM");
	===> dumb

## in terminal

	groovy:000> emacs = System.getenv("EMACS")
	===> null
	groovy:000> insideEmacs = System.getenv("INSIDE_EMACS")
	===> null
	groovy:000> term = System.getenv("TERM")
	===> xterm

I put a check before declaring a `dumb` terminal if `INSIDE_EMACS` and `EMACS` are both null, if they are set, going through with type as `AUTO` would still work fine.

I added two more tests, and I added dependencies on EasyMock and PowerMock so that I could fake the calls to `System.getenv` to test the emacs variables.  I'm not sure if you want these extra dependencies, I just wanted to show that it was working properly.  

I would have liked to check when the `getOsName` returns something with `windows` but the `init` in `create` was throwing an error (I'm on a mac).  So I had to check `os.name` in the test and set a correct expectation so that it would run on whatever os (windows included).

This would be really cool if `grails` and `groovysh` have ansi supported in `emacs`! :grin:

Let me know if there is anything else I can do.