### PR TITLE
add minimal travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java


### PR DESCRIPTION
This adds minimal Travis configuration for jline2 project.

See example of Travis builds for my fork: https://travis-ci.org/lhotari/jline2 

Travis Getting Started docs: http://docs.travis-ci.com/user/getting-started/
