### PR TITLE
Enable use of jline.terminal system property even when TERM=dumb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/src/main/java/jline/TerminalFactory.java
+++ b/src/main/java/jline/TerminalFactory.java
@@ -50,11 +50,8 @@ public class TerminalFactory
             Log.trace(new Throwable("CREATE MARKER"));
         }
 
-        String type = Configuration.getString(JLINE_TERMINAL, AUTO);
-        if ("dumb".equals(System.getenv("TERM"))) {
-            type = "none";
-            Log.debug("$TERM=dumb; setting type=", type);
-        }
+        String defaultType = "dumb".equals(System.getenv("TERM")) ? NONE : AUTO;
+        String type = Configuration.getString(JLINE_TERMINAL, defaultType);
 
         Log.debug("Creating terminal; type=", type);
 


### PR DESCRIPTION
I'd like to use the jline.terminal system property to set a default terminal. 
However this doesn't currently work when TERM=dumb in the environment.

This pull request fixes that problem.

I ran in to this issue while writing [some automated tests for Grails 3 command line shell which uses jline2](https://github.com/grails/grails-core/blob/22132660832cbd5e4a2574376dcc76b104652cbf/grails-shell/src/test/groovy/org/grails/cli/GrailsCliSpec.groovy#L250-L265). I'm using [ExpectIt](https://github.com/Alexey1Gavrilov/ExpectIt) to test shell interactions and I have to use a custom Terminal class for the tests. We have TERM=dumb environment set for gradle builds that run in Travis and that's why we hit the problem.