### PR TITLE
Removed usage of /dev/tty from TerminalLineSettings. Used ProcessBuilder from 1.7 java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,8 +268,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 
@@ -299,7 +299,7 @@
                         <configuration>
                             <signature>
                                 <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java15</artifactId>
+                                <artifactId>java17</artifactId>
                                 <version>1.0</version>
                             </signature>
                         </configuration>

--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -47,15 +47,15 @@ public final class TerminalLineSettings
 
     private long configLastFetched;
 
-    public TerminalLineSettings() throws IOException, InterruptedException {
+    public TerminalLineSettings() throws IOException, InterruptedException {        
         sttyCommand = Configuration.getString(JLINE_STTY, DEFAULT_STTY);
-        shCommand = Configuration.getString(JLINE_SH, DEFAULT_SH);
+        shCommand = Configuration.getString(JLINE_SH, DEFAULT_SH);        
         initialConfig = get("-g").trim();
         config = get("-a");
         configLastFetched = System.currentTimeMillis();
 
         Log.debug("Config: ", config);
-
+        
         // sanity check
         if (config.length() == 0) {
             throw new IOException(MessageFormat.format("Unrecognized stty code: {0}", config));
@@ -178,7 +178,7 @@ public final class TerminalLineSettings
 
     private String stty(final String args) throws IOException, InterruptedException {
         checkNotNull(args);
-        return exec(String.format("%s %s < /dev/tty", sttyCommand, args));
+        return exec(String.format("%s %s", sttyCommand, args));
     }
 
     private String exec(final String cmd) throws IOException, InterruptedException {
@@ -193,8 +193,8 @@ public final class TerminalLineSettings
 
         Log.trace("Running: ", cmd);
 
-        Process p = Runtime.getRuntime().exec(cmd);
-
+        Process p = new ProcessBuilder().redirectInput(ProcessBuilder.Redirect.INHERIT).command(cmd).start();
+        
         InputStream in = null;
         InputStream err = null;
         OutputStream out = null;

--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -34,22 +34,15 @@ public final class TerminalLineSettings
 
     public static final String DEFAULT_STTY = "stty";
 
-    public static final String JLINE_SH = "jline.sh";
 
-    public static final String DEFAULT_SH = "sh";
-
-    private String sttyCommand;
-
-    private String shCommand;
-
+    private final String sttyCommand;
     private String config;
-    private String initialConfig;
+    private final String initialConfig;
 
     private long configLastFetched;
 
     public TerminalLineSettings() throws IOException, InterruptedException {        
-        sttyCommand = Configuration.getString(JLINE_STTY, DEFAULT_STTY);
-        shCommand = Configuration.getString(JLINE_SH, DEFAULT_SH);        
+        sttyCommand = Configuration.getString(JLINE_STTY, DEFAULT_STTY);     
         initialConfig = get("-g").trim();
         config = get("-a");
         configLastFetched = System.currentTimeMillis();
@@ -109,7 +102,7 @@ public final class TerminalLineSettings
             configLastFetched = currentTime;
         }
 
-        return this.getProperty(name, config);
+        return TerminalLineSettings.getProperty(name, config);
     }
 
     /**
@@ -178,12 +171,7 @@ public final class TerminalLineSettings
 
     private String stty(final String args) throws IOException, InterruptedException {
         checkNotNull(args);
-        return exec(String.format("%s %s", sttyCommand, args));
-    }
-
-    private String exec(final String cmd) throws IOException, InterruptedException {
-        checkNotNull(cmd);
-        return exec(shCommand, "-c", cmd);
+        return exec(sttyCommand, args);
     }
 
     private String exec(final String... cmd) throws IOException, InterruptedException {


### PR DESCRIPTION
Removed usage of /dev/tty which needs to be used from JDK 1.5 to new feature from 1.7 which allows to inherit input stream received by JVM for process executed by Runtime environment. This allows to properly read terminal configuration even in case when there is no /dev/tty created. This fix allow to get information from Windows Linux terminal emulators like Cygwin.