### PR TITLE
Fix "java.lang.IllegalArgumentException: wrong number of arguments" when invoking the ConsoleRunner

### DIFF
--- a/src/main/java/jline/console/internal/ConsoleRunner.java
+++ b/src/main/java/jline/console/internal/ConsoleRunner.java
@@ -74,7 +74,8 @@ public class ConsoleRunner
         try {
             Class type = Class.forName(mainClass);
             Method method = type.getMethod("main", new Class[]{String[].class});
-            method.invoke(null);
+            String[] mainArgs = argList.toArray(new String[argList.size()]);
+            method.invoke(null, (Object) mainArgs);
         }
         finally {
             // just in case this main method is called from another program


### PR DESCRIPTION
This fixes #157.