### PR TITLE
Fixing warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,10 +266,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.1</version>
                 <configuration>
                     <source>1.5</source>
                     <target>1.5</target>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint:all,-options</arg>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
+                    <fork>true</fork>
                 </configuration>
             </plugin>
 

--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -665,6 +665,7 @@ public class ConsoleReader
      * Expand event designator such as !!, !#, !3, etc...
      * See http://www.gnu.org/software/bash/manual/html_node/Event-Designators.html
      */
+    @SuppressWarnings("fallthrough")
     protected String expandEvents(String str) throws IOException {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < str.length(); i++) {
@@ -1367,7 +1368,7 @@ public class ConsoleReader
             while (count-- > 0) {
                 int pos = buf.cursor + 1;
                 while (pos < buf.buffer.length()) {
-                    if (buf.buffer.charAt(pos) == (char) searchChar) {
+                    if (buf.buffer.charAt(pos) == searchChar) {
                         setCursorPosition(pos);
                         ok = true;
                         break;
@@ -1395,7 +1396,7 @@ public class ConsoleReader
             while (count-- > 0) {
                 int pos = buf.cursor - 1;
                 while (pos >= 0) {
-                    if (buf.buffer.charAt(pos) == (char) searchChar) {
+                    if (buf.buffer.charAt(pos) == searchChar) {
                         setCursorPosition(pos);
                         ok = true;
                         break;
@@ -1610,6 +1611,7 @@ public class ConsoleReader
      * Implements vi search ("/" or "?").
      * @throws IOException
      */
+    @SuppressWarnings("fallthrough")
     private int viSearch(char searchChar) throws IOException {
         boolean isForward = (searchChar == '/');
 
@@ -2909,7 +2911,7 @@ public class ConsoleReader
                                  * only move on an expclit entry to movement
                                  * mode.
                                  */
-                                if (state == state.NORMAL) {
+                                if (state == State.NORMAL) {
                                     moveCursor(-1);
                                 }
                                 consoleKeys.setKeyMap(KeyMap.VI_MOVE);
@@ -3600,6 +3602,7 @@ public class ConsoleReader
         }
 
         try {
+            @SuppressWarnings("deprecation")
             Object content = transferable.getTransferData(DataFlavor.plainTextFlavor);
 
             // This fix was suggested in bug #1060649 at

--- a/src/main/java/jline/console/UserInterruptException.java
+++ b/src/main/java/jline/console/UserInterruptException.java
@@ -17,6 +17,8 @@ package jline.console;
 public class UserInterruptException
     extends RuntimeException
 {
+    private static final long serialVersionUID = 6172232572140736750L;
+
     private final String partialLine;
 
     public UserInterruptException(String partialLine)

--- a/src/main/java/jline/console/completer/EnumCompleter.java
+++ b/src/main/java/jline/console/completer/EnumCompleter.java
@@ -19,7 +19,7 @@ import static jline.internal.Preconditions.checkNotNull;
 public class EnumCompleter
     extends StringsCompleter
 {
-    public EnumCompleter(Class<? extends Enum> source) {
+    public EnumCompleter(Class<? extends Enum<?>> source) {
         checkNotNull(source);
 
         for (Enum<?> n : source.getEnumConstants()) {

--- a/src/main/java/jline/console/internal/ConsoleReaderInputStream.java
+++ b/src/main/java/jline/console/internal/ConsoleReaderInputStream.java
@@ -49,7 +49,7 @@ class ConsoleReaderInputStream
     }
  
     private static class ConsoleEnumeration
-        implements Enumeration
+        implements Enumeration<InputStream>
     {
         private final ConsoleReader reader;
         private ConsoleLineInputStream next = null;
@@ -59,7 +59,7 @@ class ConsoleReaderInputStream
             this.reader = reader;
         }
  
-        public Object nextElement() {
+        public InputStream nextElement() {
             if (next != null) {
                 InputStream n = next;
                 prev = next;

--- a/src/main/java/jline/console/internal/ConsoleRunner.java
+++ b/src/main/java/jline/console/internal/ConsoleRunner.java
@@ -37,7 +37,7 @@ public class ConsoleRunner
     // FIXME: This is really ugly... re-write this
 
     public static void main(final String[] args) throws Exception {
-        List<String> argList = new ArrayList(Arrays.asList(args));
+        List<String> argList = new ArrayList<String>(Arrays.asList(args));
         if (argList.size() == 0) {
             usage();
             return;
@@ -72,8 +72,8 @@ public class ConsoleRunner
         ConsoleReaderInputStream.setIn(reader);
  
         try {
-            Class type = Class.forName(mainClass);
-            Method method = type.getMethod("main", new Class[]{String[].class});
+            Class<?> type = Class.forName(mainClass);
+            Method method = type.getMethod("main", String[].class);
             method.invoke(null);
         }
         finally {

--- a/src/main/java/jline/internal/TerminalLineSettings.java
+++ b/src/main/java/jline/internal/TerminalLineSettings.java
@@ -109,7 +109,7 @@ public final class TerminalLineSettings
             configLastFetched = currentTime;
         }
 
-        return this.getProperty(name, config);
+        return getProperty(name, config);
     }
 
     /**


### PR DESCRIPTION
Hi,

When warnings are enabled in javac, a few of them are reported in jline. This patch proposes a solution to them. I tried to resolve the warning (e.g. for static element access use class name instead of instance), but in a few cases, @SuppressWarnings seemed most appropriate to me. I'll be happy to provide rationale for the changes as needed.

Also, as a potentially controversial proposal, I also added -Xlint:all,-options and -Werror compiler options, which (for javac) enable most warnings and any warning will stop the compilation. Not sure if this is a good idea or not, please let me know if I should undo that.

What do you think?

Thanks,
    Jan