### PR TITLE
Eliminate warnings

### DIFF
--- a/src/main/java/jline/TerminalFactory.java
+++ b/src/main/java/jline/TerminalFactory.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import jline.internal.Configuration;
 import jline.internal.Log;
-import jline.internal.Preconditions;
 import static jline.internal.Preconditions.checkNotNull;
 
 /**

--- a/src/main/java/jline/WindowsTerminal.java
+++ b/src/main/java/jline/WindowsTerminal.java
@@ -23,7 +23,6 @@ import static jline.WindowsTerminal.ConsoleMode.ENABLE_ECHO_INPUT;
 import static jline.WindowsTerminal.ConsoleMode.ENABLE_LINE_INPUT;
 import static jline.WindowsTerminal.ConsoleMode.ENABLE_PROCESSED_INPUT;
 import static jline.WindowsTerminal.ConsoleMode.ENABLE_WINDOW_INPUT;
-import static jline.internal.Preconditions.checkNotNull;
 
 /**
  * Terminal implementation for Microsoft Windows. Terminal initialization in

--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -1211,7 +1211,6 @@ public class ConsoleReader
      * Deletes the previous character from the cursor position
      * @param count number of times to do it.
      * @return true if it was done.
-     * @throws IOException
      */
     private boolean viRubout(int count) throws IOException {
         boolean ok = true;
@@ -1226,7 +1225,6 @@ public class ConsoleReader
      * the line in from the right.
      * @param count Number of times to perform the operation.
      * @return true if its works, false if it didn't
-     * @throws IOException
      */
     private boolean viDelete(int count) throws IOException {
         boolean ok = true;
@@ -1243,7 +1241,6 @@ public class ConsoleReader
      * @param count The number of times to repeat
      * @return true if it completed successfully, false if not all
      *   case changes could be completed.
-     * @throws IOException
      */
     private boolean viChangeCase(int count) throws IOException {
         boolean ok = true;
@@ -1272,7 +1269,6 @@ public class ConsoleReader
      * @param count Number of times to perform the action
      * @param c The character to change to
      * @return Whether or not there were problems encountered
-     * @throws IOException
      */
     private boolean viChangeChar(int count, int c) throws IOException {
         // EOF, ESC, or CTRL-C aborts.
@@ -1302,7 +1298,6 @@ public class ConsoleReader
      *
      * @param count number of iterations
      * @return true if the move was successful, false otherwise
-     * @throws IOException
      */
     private boolean viPreviousWord(int count) throws IOException {
         boolean ok = true;
@@ -1338,7 +1333,6 @@ public class ConsoleReader
      *    (e.g. "c$" is change-to-end-of line, so we first must delete to end 
      *    of line to start the change
      * @return true if it succeeded, false otherwise
-     * @throws IOException
      */
     private boolean viDeleteTo(int startPos, int endPos, boolean isChange) throws IOException {
         if (startPos == endPos) {
@@ -1375,7 +1369,6 @@ public class ConsoleReader
      * @param startPos The starting position from which to yank
      * @param endPos The ending position to which to yank
      * @return true if the yank succeeded
-     * @throws IOException
      */
     private boolean viYankTo(int startPos, int endPos) throws IOException {
         int cursorPos = startPos;
@@ -1407,7 +1400,6 @@ public class ConsoleReader
      *
      * @param count Number of times to perform the operation.
      * @return true if it worked, false otherwise
-     * @throws IOException
      */
     private boolean viPut(int count) throws IOException {
         if (yankBuffer.length () == 0) {
@@ -1429,7 +1421,6 @@ public class ConsoleReader
      * @param count Number of times to repeat the process.
      * @param ch The character to search for
      * @return true if the char was found, false otherwise
-     * @throws IOException
      */
     private boolean viCharSearch(int count, int invokeChar, int ch) throws IOException {
         if (ch < 0 || invokeChar < 0) {
@@ -1553,7 +1544,6 @@ public class ConsoleReader
      *
      * @param count number of iterations
      * @return true if the move was successful, false otherwise
-     * @throws IOException
      */
     private boolean viNextWord(int count) throws IOException {
         int pos = buf.cursor;
@@ -1591,7 +1581,6 @@ public class ConsoleReader
      *
      * @param count Number of times to repeat the action
      * @return true if it worked.
-     * @throws IOException
      */
     private boolean viEndWord(int count) throws IOException {
         int pos = buf.cursor;
@@ -1649,7 +1638,6 @@ public class ConsoleReader
      *
      * @param count Number of times to perform the operation
      * @return true if it worked, false if you tried to delete too many words
-     * @throws IOException
      */
     private boolean unixWordRubout(int count) throws IOException {
         boolean success = true;
@@ -1706,7 +1694,6 @@ public class ConsoleReader
      * @param count The count of times to insert the string.
      * @param str The string to insert
      * @return true if the operation is a success, false otherwise
-     * @throws IOException
      */
     private boolean insert(int count, final CharSequence str) throws IOException {
         for (int i = 0; i < count; i++) {
@@ -1726,7 +1713,6 @@ public class ConsoleReader
 
     /**
      * Implements vi search ("/" or "?").
-     * @throws IOException
      */
     @SuppressWarnings("fallthrough")
     private int viSearch(char searchChar) throws IOException {
@@ -1921,7 +1907,6 @@ public class ConsoleReader
      * The logic works like so:
      * @return true if it worked, false if the cursor was not on a bracket
      *   character or if there was no matching bracket.
-     * @throws IOException
      */
     private boolean viMatch() throws IOException {
         int pos        = buf.cursor;
@@ -2084,7 +2069,6 @@ public class ConsoleReader
      * @param count The number of times to perform the transpose
      * @return true if the operation succeeded, false otherwise (e.g. transpose
      *   cannot happen at the beginning of the line).
-     * @throws IOException
      */
     private boolean transposeChars(int count) throws IOException {
         for (; count > 0; --count) {
@@ -2129,7 +2113,6 @@ public class ConsoleReader
      * complete and is returned.
      *
      * @return The completed line of text.
-     * @throws IOException
      */
     public String accept() throws IOException {
         moveToEnd();
@@ -3534,7 +3517,6 @@ public class ConsoleReader
      * @param next If true, move forward
      * @param count The number of entries to move
      * @return true if the move was successful
-     * @throws IOException
      */
     private boolean moveHistory(final boolean next, int count) throws IOException {
         boolean ok = true;

--- a/src/main/java/jline/console/KillRing.java
+++ b/src/main/java/jline/console/KillRing.java
@@ -38,7 +38,7 @@ public final class KillRing {
     }
 
     /**
-     * Creates a new kill ring of the default size. {@see DEFAULT_SIZE}.
+     * Creates a new kill ring of the default size. See {@link #DEFAULT_SIZE}.
      */
     public KillRing() {
         this(DEFAULT_SIZE);

--- a/src/main/java/jline/console/completer/ArgumentCompleter.java
+++ b/src/main/java/jline/console/completer/ArgumentCompleter.java
@@ -326,10 +326,6 @@ public class ArgumentCompleter
 
         /**
          * Check if this character is a valid escape char (i.e. one that has not been escaped)
-         *
-         * @param buffer
-         * @param pos
-         * @return
          */
         public boolean isEscapeChar(final CharSequence buffer, final int pos) {
             if (pos < 0) {

--- a/src/main/java/jline/console/history/MemoryHistory.java
+++ b/src/main/java/jline/console/history/MemoryHistory.java
@@ -261,8 +261,6 @@ public class MemoryHistory
 
     /**
      * Move to the specified index in the history
-     * @param index
-     * @return
      */
     public boolean moveTo(int index) {
         index -= offset;

--- a/src/main/java/jline/internal/Log.java
+++ b/src/main/java/jline/internal/Log.java
@@ -31,10 +31,8 @@ public final class Log
         ERROR
     }
 
-    @SuppressWarnings({"StringConcatenation"})
     public static final boolean TRACE = Boolean.getBoolean(Log.class.getName() + ".trace");
 
-    @SuppressWarnings({"StringConcatenation"})
     public static final boolean DEBUG = TRACE || Boolean.getBoolean(Log.class.getName() + ".debug");
 
     private static PrintStream output = System.err;

--- a/src/main/java/jline/internal/NonBlockingInputStream.java
+++ b/src/main/java/jline/internal/NonBlockingInputStream.java
@@ -111,7 +111,6 @@ public class NonBlockingInputStream
      * @param timeout The amount of time to wait, 0 == forever
      * @return -1 on eof, -2 if the timeout expired with no available input
      *   or the character that was read (without consuming it).
-     * @throws IOException
      */
     public int peek(long timeout) throws IOException {
         if (!nonBlockingEnabled || isShutdown) {
@@ -127,7 +126,6 @@ public class NonBlockingInputStream
      * @param timeout The amount of time to wait for the character
      * @return The character read, -1 if EOF is reached, or -2 if the
      *   read timed out.
-     * @throws IOException
      */
     public int read(long timeout) throws IOException {
         if (!nonBlockingEnabled || isShutdown) {
@@ -143,7 +141,6 @@ public class NonBlockingInputStream
      * @param timeout The amount of time to wait for the character
      * @return The character read, -1 if EOF is reached, or -2 if the
      *   read timed out.
-     * @throws IOException
      */
     private synchronized int read(long timeout, boolean isPeek) throws IOException {
         /*

--- a/src/test/java/jline/console/ConsoleReaderTest.java
+++ b/src/test/java/jline/console/ConsoleReaderTest.java
@@ -643,6 +643,8 @@ public class ConsoleReaderTest
         out.write("read and\033[D\033[D\t\n".getBytes());
 
         assertEquals("read andnd", console.readLine());
+
+        out.close();
     }
 
   /**

--- a/src/test/java/jline/console/ConsoleReaderTestSupport.java
+++ b/src/test/java/jline/console/ConsoleReaderTestSupport.java
@@ -56,9 +56,11 @@ public abstract class ConsoleReaderTestSupport
         console.setInput(new ByteArrayInputStream(buffer.getBytes()));
 
         // run it through the reader
-        String line;
-        while ((line = console.readLine((String) null)) != null) {
+        //String line;
+        //while ((line = console.readLine((String) null)) != null) {
             //System.err.println("Read line: " + line);
+        while ((console.readLine((String) null)) != null) {
+            // noop
         }
 
         assertEquals(expected, console.getCursorBuffer().toString());
@@ -74,9 +76,11 @@ public abstract class ConsoleReaderTestSupport
         console.setInput(new ByteArrayInputStream(buffer.getBytes()));
 
         // run it through the reader
-        String line;
-        while ((line = console.readLine((String) null)) != null) {
+        //String line;
+        //while ((line = console.readLine((String) null)) != null) {
             //System.err.println("Read line: " + line);
+        while ((console.readLine((String) null)) != null) {
+            // noop
         }
 
         assertEquals(pos, console.getCursorPosition ());

--- a/src/test/java/jline/console/ConsoleReaderTestSupport.java
+++ b/src/test/java/jline/console/ConsoleReaderTestSupport.java
@@ -90,7 +90,6 @@ public abstract class ConsoleReaderTestSupport
      * @param buffer The buffer
      * @param clear If true, the current buffer of the console
      *    is cleared.
-     * @throws IOException
      */
     protected void assertLine(final String expected, final Buffer buffer,
             final boolean clear) throws IOException {

--- a/src/test/java/jline/console/ConsoleReaderTestSupport.java
+++ b/src/test/java/jline/console/ConsoleReaderTestSupport.java
@@ -128,8 +128,9 @@ public abstract class ConsoleReaderTestSupport
             case BACKWARD_KILL_WORD:   return new String(new char[]{27, 127});
             case YANK:                 return "\u0019";
             case YANK_POP:             return new String(new char[]{27, 121});
+            default:
+              throw new IllegalArgumentException(key.toString());
         }
-        throw new IllegalArgumentException(key.toString());
     }
 
     protected class Buffer

--- a/src/test/java/jline/console/EditLineTest.java
+++ b/src/test/java/jline/console/EditLineTest.java
@@ -43,8 +43,6 @@ public class EditLineTest
 
     @Test
     public void testMoveToEnd() throws Exception {
-        Buffer b = new Buffer("This is a test");
-
         assertBuffer("This is a XtestX",
             new Buffer("This is a test").op(BACKWARD_WORD)
                 .append('X')

--- a/src/test/java/jline/console/ViMoveModeTest.java
+++ b/src/test/java/jline/console/ViMoveModeTest.java
@@ -1259,7 +1259,6 @@ public class ViMoveModeTest
      * CTRL-J or CTRL-M...maybe others.
      * 
      * @param enterChar The escape character that acts as enter.
-     * @throws Exception
      */
     private void testEnter(char enterChar) throws Exception {
         /*

--- a/src/test/java/jline/internal/TerminalLineSettingsTest.java
+++ b/src/test/java/jline/internal/TerminalLineSettingsTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.assertEquals;
  */
 public class TerminalLineSettingsTest
 {
-    private TerminalLineSettings settings;
-
     private final String linuxSttySample = "speed 38400 baud; rows 85; columns 244; line = 0;\n" +
             "intr = ^C; quit = ^\\; erase = ^?; kill = ^U; eof = ^D; eol = M-^?; eol2 = M-^?; swtch = M-^?; start = ^Q; stop = ^S; susp = ^Z; rprnt = ^R; werase = ^W; lnext = ^V; flush = ^O; min = 1; time = 0;\n" +
             "-parenb -parodd cs8 hupcl -cstopb cread -clocal -crtscts\n" +


### PR DESCRIPTION
This change eliminates warnings in Eclipse (and possibly other IDEs)

* Fixes incorrect javadocs
* Fixes switch statement in test class
* Fixes unclosed resources and unused vars