### PR TITLE
Fix getting encoding from the system environment

### DIFF
--- a/src/main/java/jline/internal/Configuration.java
+++ b/src/main/java/jline/internal/Configuration.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.util.Map;
 import java.util.Properties;
 
@@ -201,25 +202,34 @@ public class Configuration
         return getOsName().startsWith("hp");
     }
 
-    // FIXME: Sort out use of property access of file.encoding in InputStreamReader, consolidate should configuration access here
+    // FIXME: Sort out use of property access of file.encoding in InputStreamReader, should consolidate configuration access here
 
     public static String getFileEncoding() {
         return System.getProperty("file.encoding");
     }
 
     /**
-     * Get the default encoding.  Will first look at the LC_CTYPE environment variable, then the input.encoding
+     * Get the default encoding.  Will first look at the LC_ALL, LC_CTYPE, and LANG environment variables, then the input.encoding
      * system property, then the default charset according to the JVM.
      *
      * @return The default encoding to use when none is specified.
      */
     public static String getEncoding() {
-        // LC_CTYPE is usually in the form en_US.UTF-8
-        String envEncoding = extractEncodingFromCtype(System.getenv("LC_CTYPE"));
-        if (envEncoding != null) {
-            return envEncoding;
+        // Check for standard locale environment variables, in order of precedence, first.
+        // See http://www.gnu.org/s/libc/manual/html_node/Locale-Categories.html
+        for (String envOption : new String[]{"LC_ALL", "LC_CTYPE", "LANG"}) {
+            String envEncoding = extractEncodingFromCtype(System.getenv(envOption));
+            if (envEncoding != null) {
+                try {
+                    if (Charset.isSupported(envEncoding)) {
+                        return envEncoding;
+                    }
+                } catch (IllegalCharsetNameException e) {
+                    continue;
+                }
+            }
         }
-        return System.getProperty("input.encoding", Charset.defaultCharset().name());
+        return getString("input.encoding", Charset.defaultCharset().name());
     }
 
     /**


### PR DESCRIPTION
This change improves the ability to determine the encoding from the system by
doing the following:

* Enable looking at LC_ALL and LANG environment variables, in addition to LC_CTYPE
* Fall back to reading input.encoding from configuration file if not specified elsewhere