### PR TITLE
Remove generated dependency-reduced-pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,7 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
* Prevent unneeded dependency-reduced-pom.xml file from being generated by the
  shade plugin, and dirtying the source tree.