### PR TITLE
Option to choose if the enum will be completed in lower case

### DIFF
--- a/src/main/java/jline/console/completer/EnumCompleter.java
+++ b/src/main/java/jline/console/completer/EnumCompleter.java
@@ -20,10 +20,14 @@ public class EnumCompleter
     extends StringsCompleter
 {
     public EnumCompleter(Class<? extends Enum<?>> source) {
+        this(source, true);
+    }
+
+    public EnumCompleter(Class<? extends Enum<?>> source, boolean toLowerCase) {
         checkNotNull(source);
 
         for (Enum<?> n : source.getEnumConstants()) {
-            this.getStrings().add(n.name().toLowerCase());
+            this.getStrings().add(toLowerCase ? n.name().toLowerCase() : n.name());
         }
     }
 }


### PR DESCRIPTION
The EnumCompleter always converts the enum name to lower case. That behavior should be optional, so I added a new constructor with a boolean that you can specify it. The default is backwards compatible so it should not break anything.

Could you apply this patch?