### PR TITLE
Improve filename completer

### DIFF
--- a/src/main/java/jline/console/completer/ArgumentCompleter.java
+++ b/src/main/java/jline/console/completer/ArgumentCompleter.java
@@ -293,6 +293,11 @@ public class ArgumentCompleter
                 argpos = arg.length();
             }
             if (arg.length() > 0) {
+                // still in open quote block
+                if (quoteStart >= 0) {
+                    argpos++;
+                    arg.insert(0, buffer.charAt(quoteStart));
+                }
                 args.add(arg.toString());
             }
 

--- a/src/main/java/jline/console/completer/ArgumentCompleter.java
+++ b/src/main/java/jline/console/completer/ArgumentCompleter.java
@@ -131,10 +131,16 @@ public class ArgumentCompleter
         else {
             completer = completers.get(argIndex);
         }
+        if (completer == null) {
+            return -1;
+        }
 
         // ensure that all the previous completers are successful before allowing this completer to pass (only if strict).
         for (int i = 0; isStrict() && (i < argIndex); i++) {
             Completer sub = completers.get(i >= completers.size() ? (completers.size() - 1) : i);
+            if (sub == null) {
+                continue;
+            }
             String[] args = list.getArguments();
             String arg = (args == null || i >= args.length) ? "" : args[i];
 

--- a/src/main/java/jline/console/completer/FileNameCompleter.java
+++ b/src/main/java/jline/console/completer/FileNameCompleter.java
@@ -158,6 +158,9 @@ public class FileNameCompleter
             if (completeFolders && !file.isDirectory()) {
                 continue;
             }
+            if (ignoreFile(file)) {
+                continue;
+            }
             if (file.getAbsolutePath().startsWith(translated)) {
                 CharSequence name = file.getName();
                 /*
@@ -210,6 +213,11 @@ public class FileNameCompleter
         final int index = buffer.lastIndexOf(separator());
 
         return index + separator().length();
+    }
+
+    // hook to extend Filename COmpleter to exclude certain files / folders
+    protected boolean ignoreFile(File file) {
+        return false;
     }
 
     protected boolean hasSubfolders(File dir) {

--- a/src/main/java/jline/internal/Configuration.java
+++ b/src/main/java/jline/internal/Configuration.java
@@ -58,7 +58,13 @@ public class Configuration
 
     private static void loadProperties(final URL url, final Properties props) throws IOException {
         Log.debug("Loading properties from: ", url);
-        InputStream input = url.openStream();
+        InputStream input;
+        try {
+            input = url.openStream();
+        } catch (IOException e) {
+            Log.debug("Could not load properties from " + url + " : " + e.getMessage());
+            return;
+        }
         try {
             props.load(new BufferedInputStream(input));
         }

--- a/src/test/java/jline/console/completer/ArgumentCompleterTest.java
+++ b/src/test/java/jline/console/completer/ArgumentCompleterTest.java
@@ -65,4 +65,14 @@ public class ArgumentCompleterTest
 
         assertBuffer("some foo ", new Buffer("some fo").tab());
     }
+
+    @Test
+    public void testQuoted() throws Exception {
+        ArgumentCompleter argCompleter = new ArgumentCompleter(
+                new StringsCompleter("bar"),
+                new StringsCompleter("'foo'"));
+        console.addCompleter(argCompleter);
+
+        assertBuffer("'bar' 'foo' ", new Buffer("'bar' 'f").tab());
+    }
 }

--- a/src/test/java/jline/console/completer/FileNameCompleterTest.java
+++ b/src/test/java/jline/console/completer/FileNameCompleterTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2002-2015, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package jline.console.completer;
+
+import jline.console.ConsoleReaderTestSupport;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Tests for {@link FileNameCompleter}.
+ */
+public class FileNameCompleterTest
+    extends ConsoleReaderTestSupport
+{
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+
+    @Test
+    public void testRender() {
+        assertEquals("foo", FileNameCompleter.render("foo", null, true, true));
+        assertEquals("\'foo bar\'", FileNameCompleter.render("foo bar", null, true, true));
+        assertEquals("\'foo \\\'bar\'", FileNameCompleter.render("foo \'bar", null, true, true));
+        assertEquals("\'foo \\\'bar\'", FileNameCompleter.render("foo \'bar", "\'", true, true));
+        // need to escape double hyphens
+        assertEquals("\"foo \\\" \'bar\"", FileNameCompleter.render("foo \" \'bar", "\"", true, true));
+    }
+
+    @Test
+    public void testCompletionDefaults() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList(filename + " ", foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionSingleFile() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "file.txt";
+        testFolder.newFile(filename);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(filename + " "), candidates);
+    }
+
+    @Test
+    public void testCompletionSingleFileNoSuffix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setPrintSpaceAfterFullCompletion(false);
+        String filename = "file.txt";
+        testFolder.newFile(filename);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(filename), candidates);
+    }
+
+    @Test
+    public void testCompletionSingleFolder() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String foldername = "folder";
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionLeadingHyphen() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList(filename + " ", foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionNoBlankSuffix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setPrintSpaceAfterFullCompletion(false);
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList(filename, foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionFolder() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setCompleteFoldersOnly(true);
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(foldername + ' '), candidates);
+    }
+
+    @Test
+    public void testCompletionFolderNoBlankSuffix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setPrintSpaceAfterFullCompletion(false);
+        completor.setCompleteFoldersOnly(true);
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(foldername), candidates);
+    }
+
+    @Test
+    public void testCompletionWithBlank() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList("'" + filename + "' ", "'" + foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionWithPrefix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer + "the", 0, candidates));
+        assertEquals(Arrays.asList("'" + filename + "' ", "'" + foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionWithPrefixAndInitialHyphen() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setHandleLeadingHyphen(true);
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = "\"" + testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer + "the", 0, candidates));
+        assertEquals(Arrays.asList(filename + "\" ", foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionFolderWithPrefixAndInitialHyphen() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setHandleLeadingHyphen(true);
+        completor.setCompleteFoldersOnly(true);
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = "\"" + testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer + "the", 0, candidates));
+        assertEquals(Arrays.asList(foldername + "\" "), candidates);
+    }
+
+    @Test
+    public void testCompletionRelativePath() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setHandleLeadingHyphen(true);
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(),  completor.complete(buffer + "the", 0, candidates));
+        assertEquals(Arrays.asList("'" + filename + "' ", "'" + foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionRelativePathInitialHyphen() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setHandleLeadingHyphen(true);
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = "\"the";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(0, completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList("\"" + filename + "\" ", "\"" + foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testNestedCompletionRelativePathInitialHyphen() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setHandleLeadingHyphen(true);
+        String foldername = "the folder";
+        File folder = testFolder.newFolder(foldername);
+        File file = File.createTempFile("junit", null, folder);
+
+        String buffer = "\"the folder" + File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList(file.getName() + "\" "), candidates);
+    }
+
+    @Test
+    public void testNestedSubfolders() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        String foldername = "the folder";
+        String subfoldername = "the subfolder";
+        File folder = testFolder.newFolder(foldername);
+        File subfolder = new File(folder, subfoldername);
+        subfolder.mkdir();
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList("'" + folder.getName() + File.separator), candidates);
+    }
+
+    @Test
+    public void testNestedSubfoldersFolderOnly() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setCompleteFoldersOnly(true);
+        String foldername = "the folder";
+        String subfoldername = "the subfolder";
+        File folder = testFolder.newFolder(foldername);
+        File subfolder = new File(folder, subfoldername);
+        subfolder.mkdir();
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList("'" + folder.getName() + File.separator, "'" + folder.getName() + "' "), candidates);
+    }
+
+    @Test
+    public void testNestedSubfoldersFolderOnlyNoSpace() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setCompleteFoldersOnly(true);
+        completor.setPrintSpaceAfterFullCompletion(false);
+        String foldername = "the folder";
+        String subfoldername = "the subfolder";
+        File folder = testFolder.newFolder(foldername);
+        File subfolder = new File(folder, subfoldername);
+        subfolder.mkdir();
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList("'" + folder.getName() + File.separator, "'" + folder.getName() + "'"), candidates);
+    }
+
+    @Test
+    public void testNestedSubfoldersFolderOnlyLeadingHyphen() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setCompleteFoldersOnly(true);
+        completor.setHandleLeadingHyphen(true);
+        String foldername = "the folder";
+        String subfoldername = "the subfolder";
+        File folder = testFolder.newFolder(foldername);
+        File subfolder = new File(folder, subfoldername);
+        subfolder.mkdir();
+
+        String buffer = "\"" + testFolder.getRoot() + File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Arrays.asList(folder.getName() + File.separator, folder.getName() + "\" "), candidates);
+    }
+
+    @Test
+    public void testCompletionRelativePathInitialHyphenBuffer() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setHandleLeadingHyphen(true);
+        String filename = "the file.txt";
+        testFolder.newFile(filename);
+        console.addCompleter(completor);
+
+        assertBuffer("\"the file.txt\" ", new Buffer("\"the").tab());
+    }
+
+    @Test
+    public void testMatchFiles_Unix() {
+        if(! System.getProperty("os.name").startsWith("Windows")) {
+            FileNameCompleter completer = new FileNameCompleter();
+            List<CharSequence> candidates = new ArrayList<CharSequence>();
+            int resultIndex = completer.matchFiles("foo/bar", "/foo/bar",
+                    new File[]{new File("/foo/baroo"), new File("/foo/barbee")}, candidates, null);
+            assertEquals("foo/".length(), resultIndex);
+            assertEquals(Arrays.asList("baroo ", "barbee "), candidates);
+        }
+    }
+}

--- a/src/test/java/jline/console/completer/FileNameCompleterTest.java
+++ b/src/test/java/jline/console/completer/FileNameCompleterTest.java
@@ -379,6 +379,25 @@ public class FileNameCompleterTest
     }
 
     @Test
+    public void testCompletionIgnoreOne() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            @Override
+            protected boolean ignoreFile(File file) {
+                return file.getName().endsWith(".pdf");
+            }
+        };
+        String filename = "file.txt";
+        testFolder.newFile(filename);
+        String filename2 = "file.pdf";
+        testFolder.newFile(filename2);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(filename + " "), candidates);
+    }
+
+    @Test
     public void testMatchFiles_Unix() {
         if(! System.getProperty("os.name").startsWith("Windows")) {
             FileNameCompleter completer = new FileNameCompleter();


### PR DESCRIPTION
This fixes #90, and adds a lot of tests and some features to FileNameCompleter. The code is much more complex than before, and I would not trust it without the number of tests I added. It is possible that the code could be refactored somewhat, to save a few lines, in particular handling of closing hyphens with folders is ugly, as I though of it rather late. I will wait for feedback before spending more time on that.

The basic problem is when completing
```
mycommand "/path/to/fi
```

The completer needs to take into account plenty of things, like:
- Does a candidate ```file with blank.txt``` exist that needs to be hyphenated ```'file with blank.txt'```?
- Did the user already provide an opening hyphen, so a candidate should close them ```file.txt"```?
- Does the system expect further arguments and should add a blank after the filename?
- Does the system want to complete only files, or only folders? (There is the option of supporting both, not supported by this PR)

Depending on the context, the completion should be different.
To merge, also consider this:
- Should an variant exist of offer completion of both folders and files?
- Should handling of initial hyphens be the default (breaks current behavior)?

I did not test the changes on other operating systems than Linux.

The small commits fixing minor stuff could be merged early, if you like.