### PR TITLE
Improve filename completion

### DIFF
--- a/src/main/java/jline/console/completer/ArgumentCompleter.java
+++ b/src/main/java/jline/console/completer/ArgumentCompleter.java
@@ -131,10 +131,16 @@ public class ArgumentCompleter
         else {
             completer = completers.get(argIndex);
         }
+        if (completer == null) {
+            return -1;
+        }
 
         // ensure that all the previous completers are successful before allowing this completer to pass (only if strict).
         for (int i = 0; isStrict() && (i < argIndex); i++) {
             Completer sub = completers.get(i >= completers.size() ? (completers.size() - 1) : i);
+            if (sub == null) {
+                continue;
+            }
             String[] args = list.getArguments();
             String arg = (args == null || i >= args.length) ? "" : args[i];
 

--- a/src/main/java/jline/console/completer/ArgumentCompleter.java
+++ b/src/main/java/jline/console/completer/ArgumentCompleter.java
@@ -301,45 +301,39 @@ public class ArgumentCompleter
 
         /**
          * Returns true if the specified character is a whitespace parameter. Check to ensure that the character is not
-         * escaped by any of {@link #getQuoteChars}, and is not escaped by ant of the {@link #getEscapeChars}, and
-         * returns true from {@link #isDelimiterChar}.
+         * escaped by any {@link #getEscapeChars}, and returns true from {@link #isDelimiterChar}.
+         * Whether it delimits arguments or is within a quote context is decided elsewhere.
          *
          * @param buffer    The complete command buffer
          * @param pos       The index of the character in the buffer
          * @return          True if the character should be a delimiter
          */
         public boolean isDelimiter(final CharSequence buffer, final int pos) {
-            return !isQuoted(buffer, pos) && !isEscaped(buffer, pos) && isDelimiterChar(buffer, pos);
-        }
-
-        public boolean isQuoted(final CharSequence buffer, final int pos) {
-            return false;
-        }
-
-        public boolean isQuoteChar(final CharSequence buffer, final int pos) {
             if (pos < 0) {
                 return false;
             }
 
-            for (int i = 0; (quoteChars != null) && (i < quoteChars.length); i++) {
-                if (buffer.charAt(pos) == quoteChars[i]) {
-                    return !isEscaped(buffer, pos);
-                }
-            }
+            return isDelimiterChar(buffer, pos) && !isEscaped(buffer, pos);
+        }
 
-            return false;
+        public boolean isQuoteChar(final CharSequence buffer, final int pos) {
+            return isUnescapedCharInArray(buffer, pos, quoteChars);
         }
 
         /**
          * Check if this character is a valid escape char (i.e. one that has not been escaped)
          */
         public boolean isEscapeChar(final CharSequence buffer, final int pos) {
+            return isUnescapedCharInArray(buffer, pos, escapeChars);
+        }
+
+        protected boolean isUnescapedCharInArray(final CharSequence buffer, final int pos, char[] array) {
             if (pos < 0) {
                 return false;
             }
 
-            for (int i = 0; (escapeChars != null) && (i < escapeChars.length); i++) {
-                if (buffer.charAt(pos) == escapeChars[i]) {
+            for (int i = 0; (array != null) && (i < array.length); i++) {
+                if (buffer.charAt(pos) == array[i]) {
                     return !isEscaped(buffer, pos); // escape escape
                 }
             }
@@ -388,6 +382,9 @@ public class ArgumentCompleter
          */
         @Override
         public boolean isDelimiterChar(final CharSequence buffer, final int pos) {
+            if (pos < 0) {
+                return false;
+            }
             return Character.isWhitespace(buffer.charAt(pos));
         }
     }

--- a/src/main/java/jline/console/completer/FileNameCompleter.java
+++ b/src/main/java/jline/console/completer/FileNameCompleter.java
@@ -151,6 +151,9 @@ public class FileNameCompleter
             if (!completeFiles && !file.isDirectory()) {
                 continue;
             }
+            if (ignoreFile(file)) {
+                continue;
+            }
             if (file.getAbsolutePath().startsWith(prefix)) {
                 String renderedName = render(file, file.getName()).toString();
                 if (file.isDirectory()) {
@@ -178,6 +181,11 @@ public class FileNameCompleter
         final int index = buffer.lastIndexOf(separator());
 
         return index + separator().length();
+    }
+
+    // hook to extend Filename COmpleter to exclude certain files / folders
+    protected boolean ignoreFile(File file) {
+        return false;
     }
 
     protected boolean hasSubfolders(File dir) {

--- a/src/main/java/jline/internal/Configuration.java
+++ b/src/main/java/jline/internal/Configuration.java
@@ -58,7 +58,13 @@ public class Configuration
 
     private static void loadProperties(final URL url, final Properties props) throws IOException {
         Log.debug("Loading properties from: ", url);
-        InputStream input = url.openStream();
+        InputStream input;
+        try {
+            input = url.openStream();
+        } catch (IOException e) {
+            Log.debug("Could not load properties from " + url + " : " + e.getMessage());
+            return;
+        }
         try {
             props.load(new BufferedInputStream(input));
         }

--- a/src/test/java/jline/console/ConsoleReaderTestSupport.java
+++ b/src/test/java/jline/console/ConsoleReaderTestSupport.java
@@ -116,7 +116,7 @@ public abstract class ConsoleReaderTestSupport
         assertEquals(expected, prevLine);
     }
 
-    protected void assertEqualSet(List l1, List l2) {
+    protected void assertEqualSet(List<?> l1, List<?> l2) {
         assertTrue(l1.containsAll(l2) && l2.containsAll(l1));
     }
 

--- a/src/test/java/jline/console/ConsoleReaderTestSupport.java
+++ b/src/test/java/jline/console/ConsoleReaderTestSupport.java
@@ -11,6 +11,7 @@ package jline.console;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
 
 import jline.TerminalSupport;
 import org.junit.Before;
@@ -83,7 +84,7 @@ public abstract class ConsoleReaderTestSupport
             // noop
         }
 
-        assertEquals(pos, console.getCursorPosition ());
+        assertEquals(pos, console.getCursorPosition());
     }
 
     /**
@@ -114,6 +115,11 @@ public abstract class ConsoleReaderTestSupport
 
         assertEquals(expected, prevLine);
     }
+
+    protected void assertEqualSet(List l1, List l2) {
+        assertTrue(l1.containsAll(l2) && l2.containsAll(l1));
+    }
+
 
     private String getKeyForAction(final Operation key) {
         switch (key) {

--- a/src/test/java/jline/console/completer/FileNameCompleterTest.java
+++ b/src/test/java/jline/console/completer/FileNameCompleterTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link FileNameCompleter}.
@@ -261,6 +261,25 @@ public class FileNameCompleterTest
         // completion must start on hyphen, not after hyphen!
         assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
         assertEqualSet(Arrays.asList(folder.getName() + File.separator, folder.getName()), candidates);
+    }
+
+    @Test
+    public void testCompletionIgnoreOne() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            @Override
+            protected boolean ignoreFile(File file) {
+                return file.getName().endsWith(".pdf");
+            }
+        };
+        String filename = "file.txt";
+        testFolder.newFile(filename);
+        String filename2 = "file.pdf";
+        testFolder.newFile(filename2);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(filename + " "), candidates);
     }
 
     @Test

--- a/src/test/java/jline/console/completer/FileNameCompleterTest.java
+++ b/src/test/java/jline/console/completer/FileNameCompleterTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2002-2015, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+package jline.console.completer;
+
+import jline.console.ConsoleReaderTestSupport;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * Tests for {@link FileNameCompleter}.
+ */
+public class FileNameCompleterTest
+    extends ConsoleReaderTestSupport
+{
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void testCompletionDefaults() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEqualSet(Arrays.asList(filename + " ", foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionSingleFile() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "file.txt";
+        testFolder.newFile(filename);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(filename + " "), candidates);
+    }
+
+    @Test
+    public void testCompletionSingleFileNoSuffix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setPrintSpaceAfterFullCompletion(false);
+        String filename = "file.txt";
+        testFolder.newFile(filename);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(filename), candidates);
+    }
+
+    @Test
+    public void testCompletionSingleFolder() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String foldername = "folder";
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionLeadingHyphen() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEqualSet(Arrays.asList(filename + " ", foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionNoBlankSuffix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setPrintSpaceAfterFullCompletion(false);
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEqualSet(Arrays.asList(filename, foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionFoldersOnly() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setCompleteFolders(true);
+        completor.setCompleteFiles(false);
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(foldername + ' '), candidates);
+    }
+
+    @Test
+    public void testCompletionFoldersAndFiles() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setCompleteFolders(true);
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+
+        assertEqualSet(Arrays.asList(filename + ' ', foldername + ' ', foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionFolderNoBlankSuffix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        completor.setPrintSpaceAfterFullCompletion(false);
+        completor.setCompleteFolders(true);
+        completor.setCompleteFiles(false);
+        String filename = "file.txt";
+        String foldername = "folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(foldername), candidates);
+    }
+
+
+    @Test
+    public void testCompletionWithPrefix() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter();
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = testFolder.getRoot().getAbsolutePath() +  File.separator;
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(), completor.complete(buffer + "the", 0, candidates));
+        assertEqualSet(Arrays.asList(filename + " ", foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testCompletionRelativePath() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        //completor.setHandleLeadingHyphen(true);
+        String filename = "the file.txt";
+        String foldername = "the folder";
+        testFolder.newFile(filename);
+        testFolder.newFolder(foldername);
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        assertEquals(buffer.length(),  completor.complete(buffer + "the", 0, candidates));
+        assertEqualSet(Arrays.asList(filename + " ", foldername + File.separator), candidates);
+    }
+
+    @Test
+    public void testNestedSubfolders() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        String foldername = "the folder";
+        String subfoldername = "the subfolder";
+        File folder = testFolder.newFolder(foldername);
+        File subfolder = new File(folder, subfoldername);
+        subfolder.mkdir();
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEquals(Collections.singletonList(folder.getName() + File.separator), candidates);
+    }
+
+    @Test
+    public void testNestedSubfoldersFolderOnly() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setCompleteFolders(true);
+        completor.setCompleteFiles(false);
+        String foldername = "the folder";
+        String subfoldername = "the subfolder";
+        File folder = testFolder.newFolder(foldername);
+        File subfolder = new File(folder, subfoldername);
+        subfolder.mkdir();
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEqualSet(Arrays.asList(folder.getName() + File.separator, folder.getName() + " "), candidates);
+    }
+
+    @Test
+    public void testNestedSubfoldersFolderOnlyNoSpace() throws IOException {
+        FileNameCompleter completor = new FileNameCompleter() {
+            protected File getUserDir() {
+                // simulate being in temporary folder
+                return testFolder.getRoot();
+            }
+        };
+        completor.setCompleteFolders(true);
+        completor.setCompleteFiles(false);
+        completor.setPrintSpaceAfterFullCompletion(false);
+        String foldername = "the folder";
+        String subfoldername = "the subfolder";
+        File folder = testFolder.newFolder(foldername);
+        File subfolder = new File(folder, subfoldername);
+        subfolder.mkdir();
+
+        String buffer = "";
+        List<CharSequence> candidates = new ArrayList<CharSequence>();
+        // completion must start on hyphen, not after hyphen!
+        assertEquals(buffer.length(), completor.complete(buffer, 0, candidates));
+        assertEqualSet(Arrays.asList(folder.getName() + File.separator, folder.getName()), candidates);
+    }
+
+    @Test
+    public void testMatchFiles_Unix() {
+        if(! System.getProperty("os.name").startsWith("Windows")) {
+            FileNameCompleter completer = new FileNameCompleter();
+            List<CharSequence> candidates = new ArrayList<CharSequence>();
+            int resultIndex = completer.matchFiles("foo/bar", "/foo/bar",
+                    new File[]{new File("/foo/baroo"), new File("/foo/barbee")}, candidates);
+            assertEquals("foo/".length(), resultIndex);
+            assertEquals(Arrays.asList("baroo ", "barbee "), candidates);
+        }
+    }
+}


### PR DESCRIPTION
This supercedes #203.
This fixes #90, and adds a lot of tests and some features to FileNameCompleter and ArgumentCompleter.

ArgumentCompleter will now attempt escape candidates based on the ArgumentDelimiter. This should help e.g. with Filenames having blanks. If the argument is within the context of an opening quote, no escaping will happen, but the argumentHandler will provide a closing quote if the subcompleter suggests a candidate ending with a delimiter (blank).

FileNameCompleter can now configured to not provide a blank, it can be configured to complete folders themselves and also to not complete files (just folders if that is enabled), and users can add a filter in subclasses to exclude files based on custom logic.

I did not test the changes on other operating systems than Linux.

The small commits fixing minor stuff could be merged early, if you like.