### PR TITLE
Fix on ConsoleReader.printColumns

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -3759,7 +3759,7 @@ public class ConsoleReader
                         showLines = height - 1;
                     }
 
-                    back(resources.getString("DISPLAY_MORE").length());
+                    tputs("carriage_return");
                     if (c == 'q') {
                         // cancel
                         break;


### PR DESCRIPTION
See #216 
If enable pagination and try the function, error is raised when nagivate to next page, or the "--More--" chars are not cleared before filling the line.
