### PR TITLE
Fix for FreeBSD.

### DIFF
--- a/src/main/java/jline/TerminalFactory.java
+++ b/src/main/java/jline/TerminalFactory.java
@@ -37,6 +37,8 @@ public class TerminalFactory
 
     public static final String WINDOWS = "windows";
 
+    public static final String FREEBSD = "freebsd";
+
     public static final String NONE = "none";
 
     public static final String OFF = "off";

--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import jline.internal.Configuration;
 import jline.internal.InfoCmp;
 import jline.internal.Log;
 import jline.internal.TerminalLineSettings;
@@ -81,7 +82,15 @@ public class UnixTerminal
         // Set the console to be character-buffered instead of line-buffered.
         // Make sure we're distinguishing carriage return from newline.
         // Allow ctrl-s keypress to be used (as forward search)
-        settings.set("-icanon min 1 -icrnl -inlcr -ixon");
+        //
+        // Please note that FreeBSD does not seem to support -icrnl and thus
+        // has to be handled separately. Otherwise the console will be "stuck"
+        // and will neither accept input nor print anything to stdout.
+        if (Configuration.getOsName().contains(TerminalFactory.FREEBSD)) {
+            settings.set("-icanon min 1 -inlcr -ixon");
+        } else {
+            settings.set("-icanon min 1 -icrnl -inlcr -ixon");
+        }
         settings.undef("dsusp");
 
         setEchoEnabled(false);


### PR DESCRIPTION
Unfortunately, on FreeBSD, the console is "stuck".
This means that the first prompt is shown but afterwards neither input is echoed nor accepted rendering jline2 completely non-functional.
This patch fixes the issue.