### PR TITLE
Remove Useless parentheses

### DIFF
--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -148,7 +148,7 @@ public class UnixTerminal
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
-            Log.error("Failed to ", (enabled ? "enable" : "disable"), " echo", e);
+            Log.error("Failed to ", enabled ? "enable" : "disable", " echo", e);
         }
     }
 

--- a/src/main/java/jline/console/ConsoleKeys.java
+++ b/src/main/java/jline/console/ConsoleKeys.java
@@ -173,7 +173,7 @@ public class ConsoleKeys {
                         && line.charAt(i) != ' ' && line.charAt(i) != '\t'
                         ; i++);
                 keySeq = line.substring(0, i);
-                equivalency = (i + 1 < line.length() && line.charAt(i) == ':' && line.charAt(i + 1) == '=');
+                equivalency = i + 1 < line.length() && line.charAt(i) == ':' && line.charAt(i + 1) == '=';
                 i++;
                 if (equivalency) {
                     i++;

--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -478,7 +478,7 @@ public class ConsoleReader
 
     public void setPrompt(final String prompt) {
         this.prompt = prompt;
-        this.promptLen = ((prompt == null) ? 0 : wcwidth(Ansi.stripAnsi(lastLine(prompt)), 0));
+        this.promptLen = (prompt == null) ? 0 : wcwidth(Ansi.stripAnsi(lastLine(prompt)), 0);
     }
 
     public String getPrompt() {

--- a/src/main/java/jline/console/CursorBuffer.java
+++ b/src/main/java/jline/console/CursorBuffer.java
@@ -92,7 +92,7 @@ public class CursorBuffer
         cursor += str.length();
 
         if (isOverTyping() && cursor < buffer.length()) {
-            buffer.delete(cursor, (cursor + str.length()));
+            buffer.delete(cursor, cursor + str.length());
         }
     }
 

--- a/src/main/java/jline/console/KillRing.java
+++ b/src/main/java/jline/console/KillRing.java
@@ -152,7 +152,7 @@ public final class KillRing {
     private void prev() {
         head--;
         if (head == -1) {
-            int x = (slots.length - 1);
+            int x = slots.length - 1;
             for (; x >= 0; x--) {
                 if (slots[x] != null) {
                     break;

--- a/src/main/java/jline/internal/NonBlockingInputStream.java
+++ b/src/main/java/jline/internal/NonBlockingInputStream.java
@@ -174,7 +174,7 @@ public class NonBlockingInputStream
                 notify();
             }
             
-            boolean isInfinite = (timeout <= 0L);
+            boolean isInfinite = timeout <= 0L;
             
             /*
              * So the thread is currently doing the reading for us. So


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

Zeeshan