### PR TITLE
Private methods that don't access instance data should be static

### DIFF
--- a/src/main/java/jline/WindowsTerminal.java
+++ b/src/main/java/jline/WindowsTerminal.java
@@ -199,11 +199,11 @@ public class WindowsTerminal
     //
     // Native Bits
     //
-    private int getConsoleMode() {
+    private static int getConsoleMode() {
         return WindowsSupport.getConsoleMode();
     }
 
-    private void setConsoleMode(int mode) {
+    private static void setConsoleMode(int mode) {
         WindowsSupport.setConsoleMode(mode);
     }
 
@@ -291,15 +291,15 @@ public class WindowsTerminal
         return sb.toString().getBytes();
     }
 
-    private int getConsoleOutputCodepage() {
+    private static int getConsoleOutputCodepage() {
         return Kernel32.GetConsoleOutputCP();
     }
 
-    private int getWindowsTerminalWidth() {
+    private static int getWindowsTerminalWidth() {
         return WindowsSupport.getWindowsTerminalWidth();
     }
 
-    private int getWindowsTerminalHeight() {
+    private static int getWindowsTerminalHeight() {
         return WindowsSupport.getWindowsTerminalHeight();
     }
 

--- a/src/main/java/jline/console/ConsoleKeys.java
+++ b/src/main/java/jline/console/ConsoleKeys.java
@@ -244,7 +244,7 @@ public class ConsoleKeys {
         }
     }
 
-    private String translateQuoted(String keySeq) {
+    private static String translateQuoted(String keySeq) {
         int i;
         String str = keySeq.substring( 1, keySeq.length() - 1 );
         keySeq = "";
@@ -330,7 +330,7 @@ public class ConsoleKeys {
         return keySeq;
     }
 
-    private char getKeyFromName(String name) {
+    private static char getKeyFromName(String name) {
         if ("DEL".equalsIgnoreCase(name) || "Rubout".equalsIgnoreCase(name)) {
             return 0x7f;
         } else if ("ESC".equalsIgnoreCase(name) || "Escape".equalsIgnoreCase(name)) {

--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -284,7 +284,7 @@ public class ConsoleReader
         }
     }
 
-    private URL getInputRc() throws IOException {
+    private static URL getInputRc() throws IOException {
         String path = Configuration.getString(JLINE_INPUTRC);
         if (path == null) {
             File f = new File(Configuration.getUserHome(), INPUT_RC);
@@ -587,7 +587,7 @@ public class ConsoleReader
      * prompt is returned if no '\n' characters are present.
      * null is returned if prompt is null.
      */
-    private String lastLine(String str) {
+    private static String lastLine(String str) {
         if (str == null) return "";
         int last = str.lastIndexOf("\n");
 
@@ -1429,7 +1429,7 @@ public class ConsoleReader
         return ok;
     }
 
-    private char switchCase(char ch) {
+    private static char switchCase(char ch) {
         if (Character.isUpperCase(ch)) {
             return Character.toLowerCase(ch);
         }
@@ -1843,7 +1843,7 @@ public class ConsoleReader
      * @return 1 is square, 2 curly, 3 parent, or zero for none.  The value
      *   will be negated if it is the closing form of the bracket.
      */
-    private int getBracketType (char ch) {
+    private static int getBracketType (char ch) {
         switch (ch) {
             case '[': return  1;
             case ']': return -1;
@@ -3986,7 +3986,7 @@ public class ConsoleReader
      * @param c     The character to test
      * @return      True if it is a delimiter
      */
-    private boolean isDelimiter(final char c) {
+    private static boolean isDelimiter(final char c) {
         return !Character.isLetterOrDigit(c);
     }
 
@@ -3999,7 +3999,7 @@ public class ConsoleReader
      * @param c The character to check
      * @return true if the character is a whitespace
      */
-    private boolean isWhitespace(final char c) {
+    private static boolean isWhitespace(final char c) {
         return Character.isWhitespace (c);
     }
 

--- a/src/main/java/jline/console/completer/CandidateListCompletionHandler.java
+++ b/src/main/java/jline/console/completer/CandidateListCompletionHandler.java
@@ -205,7 +205,7 @@ public class CandidateListCompletionHandler
     /**
      * @return true is all the elements of <i>candidates</i> start with <i>starts</i>
      */
-    private boolean startsWith(final String starts, final String[] candidates) {
+    private static boolean startsWith(final String starts, final String[] candidates) {
         for (String candidate : candidates) {
             if (!candidate.startsWith(starts)) {
                 return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.
Zeeshan