### PR TITLE
Fixes for usage in combination with loadwatch

### DIFF
--- a/src/main/java/jline/NoInterruptUnixTerminal.java
+++ b/src/main/java/jline/NoInterruptUnixTerminal.java
@@ -10,6 +10,8 @@ package jline;
 
 // Based on Apache Karaf impl
 
+import java.util.Arrays;
+
 /**
  * Non-interruptible (via CTRL-C) {@link UnixTerminal}.
  *
@@ -39,7 +41,7 @@ public class NoInterruptUnixTerminal
     @Override
     public void restore() throws Exception {
         if (intr != null) {
-            getSettings().set("intr", intr);
+            getSettings().set(Arrays.asList("intr", intr));
         }
         super.restore();
     }

--- a/src/main/java/jline/UnixTerminal.java
+++ b/src/main/java/jline/UnixTerminal.java
@@ -8,6 +8,8 @@
  */
 package jline;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -87,9 +89,9 @@ public class UnixTerminal
         // has to be handled separately. Otherwise the console will be "stuck"
         // and will neither accept input nor print anything to stdout.
         if (Configuration.getOsName().contains(TerminalFactory.FREEBSD)) {
-            settings.set("-icanon min 1 -inlcr -ixon");
+            settings.set(Arrays.asList("-icanon", "min 1", "-inlcr", "-ixon"));
         } else {
-            settings.set("-icanon min 1 -icrnl -inlcr -ixon");
+            settings.set(Arrays.asList("-icanon", "min 1", "-icrnl", "-inlcr", "-ixon"));
         }
         settings.undef("dsusp");
 
@@ -137,10 +139,10 @@ public class UnixTerminal
     public synchronized void setEchoEnabled(final boolean enabled) {
         try {
             if (enabled) {
-                settings.set("echo");
+                settings.set(Collections.singletonList("echo"));
             }
             else {
-                settings.set("-echo");
+                settings.set(Collections.singletonList("-echo"));
             }
             super.setEchoEnabled(enabled);
         }
@@ -173,7 +175,7 @@ public class UnixTerminal
     {
         try {
             if (intr != null) {
-                settings.set("intr", intr);
+                settings.set(Arrays.asList("intr", intr));
             }
         }
         catch (Exception e) {
@@ -205,7 +207,7 @@ public class UnixTerminal
     {
         try {
             if (lnext != null) {
-                settings.set("lnext", lnext);
+                settings.set(Arrays.asList("lnext", lnext));
             }
         }
         catch (Exception e) {


### PR DESCRIPTION
This fixes the problems described in bug #230.

When using jline to create a new ConsoleReader object
in combination with loadwatch, the process never returned.

In jline1, a long time ago, Runtime.getRuntime().exec(cmd)
was used to execute commands. This was migrated to the
ProcessBuilder API later, which is the recommended way.

In the meantime, the commands (as plain strings) were split
manually with split(""), whereas Runtime.getRuntime().exec(cmd)
was using a StringTokenizer internally.

The java implementations here are different, and one needs to
be carefull when passing down stuff to the ProcessBuilder.
See also:
http://stackoverflow.com/questions/6856028/difference-between-processbuilder-and-runtime-exec

My implementation just uses explicit List<String> calls everywhere
to make clear how arguments are split, which fixes the usage of
jline in combination with loadwatch.
