### PR TITLE
Fix #247 The number in "Display all n possibilities?" differs from the actual number of commands listed

### DIFF
--- a/src/main/java/jline/console/completer/CandidateListCompletionHandler.java
+++ b/src/main/java/jline/console/completer/CandidateListCompletionHandler.java
@@ -117,7 +117,7 @@ public class CandidateListCompletionHandler
         if (distinct.size() > reader.getAutoprintThreshold()) {
             //noinspection StringConcatenation
             reader.println();
-            reader.print(Messages.DISPLAY_CANDIDATES.format(candidates.size()));
+            reader.print(Messages.DISPLAY_CANDIDATES.format(distinct.size()));
             reader.flush();
 
             int c;


### PR DESCRIPTION
This fixes #247. It just changes the number in `"Display all n possibilities?"` from the size of the variable `candidates` (duplication included) to that of `distinct` (duplication excluded).