### PR TITLE
make "fresh-line" handling optional

### DIFF
--- a/src/main/java/org/jline/reader/LineReader.java
+++ b/src/main/java/org/jline/reader/LineReader.java
@@ -280,6 +280,8 @@ public interface LineReader {
         LIST_ROWS_FIRST,
         GLOB_COMPLETE,
         MENU_COMPLETE,
+        /** if set and not at start of line before prompt, move to new line */
+        AUTO_FRESH_LINE,
         AUTO_PARAM_SLASH(true),
         AUTO_REMOVE_SLASH(true);
 

--- a/src/main/java/org/jline/reader/impl/LineReaderImpl.java
+++ b/src/main/java/org/jline/reader/impl/LineReaderImpl.java
@@ -475,18 +475,8 @@ public class LineReaderImpl implements LineReader, Flushable
 
             // Move into application mode
             terminal.puts(Capability.keypad_xmit);
-            // Make sure we position the cursor on column 0
-            AttributedStringBuilder sb = new AttributedStringBuilder();
-            sb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.BLACK + AttributedStyle.BRIGHT));
-            sb.append("~");
-            sb.style(AttributedStyle.DEFAULT);
-            for (int i = 0; i < size.getColumns() - 1; i++) {
-                sb.append(" ");
-            }
-            sb.append(KeyMap.key(terminal, Capability.carriage_return));
-            sb.append(" ");
-            sb.append(KeyMap.key(terminal, Capability.carriage_return));
-            print(sb.toAnsi(terminal));
+            if (isSet(Option.AUTO_FRESH_LINE))
+                freshLine();
 
             setPrompt(prompt);
             setRightPrompt(rightPrompt);
@@ -584,6 +574,21 @@ public class LineReaderImpl implements LineReader, Flushable
                 terminal.handle(Signal.CONT, previousContHandler);
             }
         }
+    }
+
+    /** Make sure we position the cursor on column 0 */
+    void freshLine() {
+        AttributedStringBuilder sb = new AttributedStringBuilder();
+        sb.style(AttributedStyle.DEFAULT.foreground(AttributedStyle.BLACK + AttributedStyle.BRIGHT));
+        sb.append("~");
+        sb.style(AttributedStyle.DEFAULT);
+        for (int i = 0; i < size.getColumns() - 1; i++) {
+            sb.append(" ");
+        }
+        sb.append(KeyMap.key(terminal, Capability.carriage_return));
+        sb.append(" ");
+        sb.append(KeyMap.key(terminal, Capability.carriage_return));
+        print(sb.toAnsi(terminal));
     }
 
     @Override


### PR DESCRIPTION
see issue #257 
The way we force the cursor to the start of a possibly-fresh line breaks copy-and-paste on terminals that track line-wrapping (including xterm and many xterm clones).  It also may fail on non-ansi-style terminals, since it depends on vt100-style line-wrapping.

I moved the logic for moving to the fresh line into a new method named freshLine, and only call the method when a new AUTO_FRESH_LINE option is set.  By default it is not set, since I think this logic belongs in the application rather than jline, but we change the default if you disagree.