### PR TITLE
Address #277: Allow setting max history-size for FileHistory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
     http://www.opensource.org/licenses/bsd-license.php
 
 -->
+## Unreleased
+* #277: Allow setting max history-size. `FileHistory` allows delayed
+  init (to allow setMaxSize to take effect) and `ConsoleReader`
+  exposes ability to read inputrc settings.
+
+## [JLine 2.14.3][2_14_3]
+* (unrecorded)
+
 ## [Jline 2.9][2_9]
 [2_9]: https://oss.sonatype.org/content/groups/public/jline/jline/2.9
                                                                      

--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -287,7 +287,11 @@ public class ConsoleReader implements Closeable
         }
     }
 
-    private static URL getInputRc() throws IOException {
+    /**
+     * Retrieve the URL for the inputrc configuration file in effect. Intended
+     * use is for instantiating ConsoleKeys, to read inputrc variables.
+     */
+    public static URL getInputRc() throws IOException {
         String path = Configuration.getString(JLINE_INPUTRC);
         if (path == null) {
             File f = new File(Configuration.getUserHome(), INPUT_RC);

--- a/src/main/java/jline/console/history/FileHistory.java
+++ b/src/main/java/jline/console/history/FileHistory.java
@@ -39,8 +39,29 @@ public class FileHistory
 {
     private final File file;
 
+    /**
+     * Load a history file into memory, truncating to default max size.
+     */
     public FileHistory(final File file) throws IOException {
+        this(file, true);
+    }
+
+    /**
+     * Create a FileHistory, but only initialize if doInit is true. This allows
+     * setting maxSize or other settings; call load() before using if doInit is
+     * false.
+     */
+    public FileHistory(final File file, final boolean doInit) throws IOException {
         this.file = checkNotNull(file).getAbsoluteFile();
+        if (doInit) {
+            load();
+        }
+    }
+
+    /**
+     * Load history from file, e.g. if using delayed init.
+     */
+    public void load() throws IOException {
         load(file);
     }
 


### PR DESCRIPTION
For #277. Two parts:

- Add delayed-init constructor for `FileHistory` so that `setMaxSize` can be called *before* load (otherwise backing file is truncated)
- Expose `ConsoleReader.getInputRc` to allow retrieval of `history-size` variable from inputrc for use in `FileHistory.setMaxSize`