### PR TITLE
Only print LF, not CR LF after an input line on non-Windows

### DIFF
--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -28,6 +28,7 @@ import java.io.Writer;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.lang.System;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
@@ -3483,12 +3484,13 @@ public class ConsoleReader implements Closeable
         println();
     }
 
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
     /**
      * Output a platform-dependant newline.
      */
     public void println() throws IOException {
-        tputs("carriage_return");
-        rawPrint('\n');
+        rawPrint(LINE_SEPARATOR);
     }
 
     /**

--- a/src/test/java/jline/console/ConsoleReaderTest.java
+++ b/src/test/java/jline/console/ConsoleReaderTest.java
@@ -106,6 +106,19 @@ public class ConsoleReaderTest
     }
 
     @Test
+    public void testReadlineOutputsThePlatformLineSeparator() throws Exception {
+        ConsoleReader consoleReader = createConsole("Sample String\r\n");
+        assertNotNull(consoleReader);
+        String line = consoleReader.readLine();
+        String out = output.toString();
+        if (TerminalFactory.get() instanceof WindowsTerminal) {
+            assertEquals("Sample String\r\n", out);
+        } else {
+            assertEquals("Sample String\n", out);
+        }
+    }
+
+    @Test
     public void testReadlineWithUnicode() throws Exception {
         System.setProperty("input.encoding", "UTF-8");
         ConsoleReader consoleReader = createConsole("\u6771\u00E9\u00E8\r\n");


### PR DESCRIPTION
* We use the property as System.lineSeparator() is Java 7+.
* Fixes #282.