### PR TITLE
Emacs wants no echo, but can use color

### DIFF
--- a/src/main/java/jline/UnsupportedTerminal.java
+++ b/src/main/java/jline/UnsupportedTerminal.java
@@ -19,8 +19,12 @@ public class UnsupportedTerminal
     extends TerminalSupport
 {
     public UnsupportedTerminal() {
+        this(false, true);
+    }
+
+    public UnsupportedTerminal(boolean ansiSupported, boolean echoEnabled) {
         super(false);
-        setAnsiSupported(false);
-        setEchoEnabled(true);
+        setAnsiSupported(ansiSupported);
+        setEchoEnabled(echoEnabled);
     }
 }

--- a/src/main/java/jline/console/ConsoleReader.java
+++ b/src/main/java/jline/console/ConsoleReader.java
@@ -3235,9 +3235,7 @@ public class ConsoleReader implements Closeable
 
             if (i == -1 && buf.buffer.length() == 0) {
               return null;
-            }
-
-            if (i == -1 || i == '\n') {
+            } else if (i == -1 || i == '\n') {
                 return finishBuffer();
             } else if (i == '\r') {
                 skipLF = true;
@@ -3245,7 +3243,7 @@ public class ConsoleReader implements Closeable
             } else {
                 buf.buffer.append((char) i);
             }
-        }
+        }        
     }
 
     //

--- a/src/test/java/jline/TerminalFactoryTest.java
+++ b/src/test/java/jline/TerminalFactoryTest.java
@@ -18,7 +18,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.powermock.api.easymock.PowerMock.mockStaticPartial;
 import static org.powermock.api.easymock.PowerMock.replayAll;
 import static org.powermock.api.easymock.PowerMock.verifyAll;
@@ -65,26 +67,19 @@ public class TerminalFactoryTest
     }
 
     @Test
-    public void testConfigureDumbTerminalEmacs() {
+    public void testConfigureDumbTerminalInsideEmacs() {
         mockStaticPartial(System.class, "getenv");
-        mockStaticPartial(Configuration.class, "getOsName");
-
-        String osString = System.getProperty("os.name").toLowerCase();
-        String expectedTerminalClassName = osString.contains("windows") ?
-                "jline.AnsiWindowsTerminal" :
-                "jline.UnixTerminal";
-        expect(Configuration.getOsName()).andReturn(osString).anyTimes();
 
         expect(System.getenv("TERM")).andReturn("dumb");
-        expect(System.getenv("EMACS")).andReturn("t");
         expect(System.getenv("INSIDE_EMACS")).andReturn("24.3.1,comint");
-        expect(System.getenv("OSV_CPUS")).andReturn(null);
         replayAll();
 
         Terminal t = TerminalFactory.get();
         verifyAll();
         assertNotNull(t);
-        assertEquals(expectedTerminalClassName, t.getClass().getName());
+        assertEquals(UnsupportedTerminal.class.getName(), t.getClass().getName());
+        assertTrue(t.isAnsiSupported());
+        assertFalse(t.isEchoEnabled());
     }
 
     @Test
@@ -92,7 +87,6 @@ public class TerminalFactoryTest
         mockStaticPartial(System.class, "getenv");
 
         expect(System.getenv("TERM")).andReturn("dumb");
-        expect(System.getenv("EMACS")).andReturn(null);
         expect(System.getenv("INSIDE_EMACS")).andReturn(null);
         replayAll();
 
@@ -100,5 +94,7 @@ public class TerminalFactoryTest
         verifyAll();
         assertNotNull(t);
         assertEquals(UnsupportedTerminal.class.getName(), t.getClass().getName());
+        assertFalse(t.isAnsiSupported());
+        assertTrue(t.isEchoEnabled());
     }
 }


### PR DESCRIPTION
This pull request changes how JLine supports emacs.

Previously emacs was supported as a platform terminal (e.g. `UnixTerminal`). This had the problem that unnecessary echo was produced to stdout. Furthermore, emacs is a `dumb` terminal, so it does not actually support any of the features of a full terminal.

With this PR emacs will use the `UnsupportedTerminal`, but unlike for other `dumb` terminals, ANSI support is turned on and echo is turned off.