### PR TITLE
Proposed fix for `SecurityException` attempting to read config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * #277: Allow setting max history-size. `FileHistory` allows delayed
   init (to allow setMaxSize to take effect) and `ConsoleReader`
   exposes ability to read inputrc settings.
+* #272: Handle `SecurityException` during initialisation if access to
+  the config file is denied.
 
 ## [JLine 2.14.3][2_14_3]
 * (unrecorded)

--- a/src/main/java/jline/internal/Configuration.java
+++ b/src/main/java/jline/internal/Configuration.java
@@ -45,17 +45,22 @@ public class Configuration
     private static volatile Properties properties;
 
     private static Properties initProperties() {
-        URL url = determineUrl();
         Properties props = new Properties();
         try {
-            loadProperties(url, props);
-        }
-        catch (FileNotFoundException e) {
-            // debug here and no stack trace, as this can happen normally if default jline.rc file is missing
-            Log.debug("Unable to read configuration: ", e.toString());
-        }
-        catch (IOException e) {
-            Log.warn("Unable to read configuration from: ", url, e);
+            URL url = determineUrl();
+            try {
+                loadProperties(url, props);
+            }
+            catch (FileNotFoundException e) {
+                // debug here and no stack trace, as this can happen normally if default jline.rc file is missing
+                Log.debug("Unable to read configuration: ", e.toString());
+            }
+            catch (IOException e) {
+                Log.warn("Unable to read configuration from: ", url, e);
+            }
+        } catch (SecurityException e) {
+            // Omitting stack trace as it's a fairly normal condition, but I think you'd still want to know about it.
+            Log.info("Security policy denied reading configuration file");
         }
         return props;
     }
@@ -83,6 +88,12 @@ public class Configuration
         }
     }
 
+    /**
+     * Determines the URL to read the configuration from.
+     *
+     * @return the URL.
+     * @throws SecurityException if no override is provided, and access to the user's default config file is denied.
+     */
     private static URL determineUrl() {
         // See if user has customized the configuration location via sysprop
         String tmp = System.getProperty(JLINE_CONFIGURATION);

--- a/src/main/java/jline/internal/Urls.java
+++ b/src/main/java/jline/internal/Urls.java
@@ -21,6 +21,16 @@ import java.net.URL;
  */
 public class Urls
 {
+    /**
+     * <p>Creates a URL from a string.</p>
+     *
+     * <p>If the string represents a valid URL in a supported protocol, that URL is returned.
+     *    Otherwise, the string is treated as a file path converted to a URL.</p>
+     *
+     * @param file the file path.
+     * @return the URL.
+     * @throws SecurityException if the file path cannot be accessed.
+     */
     public static URL create(final String input) {
         if (input == null) {
             return null;
@@ -33,6 +43,13 @@ public class Urls
         }
     }
 
+    /**
+     * Creates a URL for a file path.
+     *
+     * @param file the file path.
+     * @return the URL.
+     * @throws SecurityException if the file path cannot be accessed.
+     */
     public static URL create(final File file) {
         try {
             return file != null ? file.toURI().toURL() : null;


### PR DESCRIPTION
`SecurityException` can be thrown when converting `File` to `URL`
and the code was not taking this into account.

This fix accepts that it will propagate up to the point where
the file is read, and the `SecurityException` is caught there,
since opening the file could throw one as well anyway.

Fixes #272.
